### PR TITLE
Add resource table to avoid ambigous column name error

### DIFF
--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -110,7 +110,9 @@ module ForestLiana
     end
 
     def select
-      column_names = @resource.column_names.map { |name| name.to_sym }
+      column_names = @resource.column_names.map do |name|
+        "#{@resource.table_name}.#{name}".to_sym
+      end
       if @field_names_requested
         column_names & @field_names_requested
       else


### PR DESCRIPTION
I encountered this error when loading my table.
```
ActiveRecord::StatementInvalid (PG::AmbiguousColumn: ERROR:  column reference "id" is ambiguous
LINE 1: ..." AS t7_r26, "sessions"."coachee_type" AS t7_r27, id, client...
```
The error will be raised when calling `getter.records` on `resources_controller.rb`. So, I modified the code a bit to fix that. Thanks