### PR TITLE
Fixed type instance variable

### DIFF
--- a/app/controllers/forest_liana/sessions_controller.rb
+++ b/app/controllers/forest_liana/sessions_controller.rb
@@ -25,7 +25,7 @@ module ForestLiana
     def check_user
       if has_internal_authentication?
         # NOTICE: Use the ForestUser table for authentication.
-        user = user_class.find_by(email: params['email'])
+        user = @user_class.find_by(email: params['email'])
         user if !user.blank? && authenticate_internal_user(user['password_digest'])
       else
         # NOTICE: Query Forest server for authentication.


### PR DESCRIPTION
Here a quick fix that prevent this:

```
….1/app/controllers/forest_liana/sessions_controller.rb:  32:in `check_user'
….1/app/controllers/forest_liana/sessions_controller.rb:   8:in `create'
…e/gems/actionview-4.2.7.1/lib/action_view/rendering.rb:  30:in `process'
/usr/local/bundle/gems/rack-cors-0.4.0/lib/rack/cors.rb:  80:in `call'
```