### PR TITLE
Test uploaded file against Base64 regexp for Carrierwave

### DIFF
--- a/app/deserializers/forest_liana/resource_deserializer.rb
+++ b/app/deserializers/forest_liana/resource_deserializer.rb
@@ -97,7 +97,11 @@ module ForestLiana
 
       @params['data']['attributes'].each do |key, value|
         if value && carrierwave_attribute?(key)
-          @attributes[key] = ForestLiana::Base64StringIO.new(value)
+          if value.match(/\Adata:\w+\/.+;base64,.+/)
+            @attributes[key] = ForestLiana::Base64StringIO.new(value)
+          else
+            @attributes.delete(key)
+          end
         end
       end
     end


### PR DESCRIPTION
When I update a model via Forest Admin, browser submits image attribute even if it's marked readonly and if it hasn't changed. In this case browser passes a URL for the existing image, which caused `ForestLiana::Base64StringIO.initialize` to throw an `ArgumentError`.

This PR is to ignore carrierwave fields (by removing related key from attributes hash) which contain incorrect (non-base64 data) strings.