### PR TITLE
[+] Smart Fields - Support belongs_to smart fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- Smart Fields - Support belongs_to smart fields.
 
 ## RELEASE 1.6.1 - 2017-04-26
 ### Fixed

--- a/lib/forest_liana/collection.rb
+++ b/lib/forest_liana/collection.rb
@@ -62,6 +62,21 @@ module ForestLiana::Collection
       end
     end
 
+    def belongs_to(name, opts, &block)
+      model.fields << opts.merge({
+        field: name,
+        :'is-searchable' => false,
+        type: 'String'
+      })
+
+      if serializer_name && ForestLiana::UserSpace.const_defined?(
+          serializer_name)
+        ForestLiana::UserSpace.const_get(serializer_name).class_eval do
+          has_one(name, name: name, include_data: true, &block)
+        end
+      end
+    end
+
     private
 
     def model


### PR DESCRIPTION
Example:

```ruby
class Forest::Customer
  include ForestLiana::Collection

  collection :customers

  belongs_to :delivery, reference: 'delivery_men.id' do
    DeliveryMan.first
  end
end

```