### PR TITLE
Development Autoreload - Prevent "A copy of ForestLiana::ResourcesController has been removed from the module tree but is still active!" in development mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - Records Updates - Fix unexpected "serialize" field update on other record attributes update.
+- Development Autoreload - Prevent "A copy of ForestLiana::ResourcesController has been removed from the module tree but is still active!" in development mode.
 
 ## RELEASE 1.6.12 - 2017-06-20
 ### Fixed

--- a/app/controllers/forest_liana/resources_controller.rb
+++ b/app/controllers/forest_liana/resources_controller.rb
@@ -14,7 +14,7 @@ module ForestLiana
     end
 
     def index
-      getter = ResourcesGetter.new(@resource, params)
+      getter = ForestLiana::ResourcesGetter.new(@resource, params)
       getter.perform
 
       render serializer: nil, json: serialize_models(getter.records,
@@ -24,7 +24,7 @@ module ForestLiana
     end
 
     def show
-      getter = ResourceGetter.new(@resource, params)
+      getter = ForestLiana::ResourceGetter.new(@resource, params)
       getter.perform
 
       render serializer: nil, json:
@@ -32,7 +32,7 @@ module ForestLiana
     end
 
     def create
-      creator = ResourceCreator.new(@resource, params)
+      creator = ForestLiana::ResourceCreator.new(@resource, params)
       creator.perform
 
       if creator.errors
@@ -48,7 +48,7 @@ module ForestLiana
     end
 
     def update
-      updater = ResourceUpdater.new(@resource, params)
+      updater = ForestLiana::ResourceUpdater.new(@resource, params)
       updater.perform
 
       if updater.errors

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 ForestLiana::Engine.routes.draw do
-  router = ::ForestLiana::Router.new
+  router = ForestLiana::Router.new
 
   # Onboarding
   get '/' => 'apimaps#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 ForestLiana::Engine.routes.draw do
-  router = ForestLiana::Router.new
+  router = ::ForestLiana::Router.new
 
   # Onboarding
   get '/' => 'apimaps#index'


### PR DESCRIPTION
## Pull Request checklist:

- [x] Write an explicit title for the Pull Request
- [x] Write changes made in the CHANGELOG.md
- [x] Test manually the implemented changes
- [x] Wonder if you can improve the existing code
