### PR TITLE
[*] Server Start - Use namespace for ResourcesController to prevent conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Fixed
+- Namespacing - Fix conflict with ResourcesController
 
 ## RELEASE 2.8.4 - 2018-06-21
 ### Changed

--- a/app/services/forest_liana/controller_factory.rb
+++ b/app/services/forest_liana/controller_factory.rb
@@ -16,7 +16,7 @@ module ForestLiana
     end
 
     def controller_for(active_record_class)
-      controller = Class.new(ResourcesController) { }
+      controller = Class.new(ForestLiana::ResourcesController) { }
 
       ForestLiana::ControllerFactory.define_controller(active_record_class, controller)
       controller


### PR DESCRIPTION
Hi,
I couldn't launch my server with forest-rails gem because the class `ControllerFactory` was using `ResourcesController` which is a common name, used in my case in another gem.
So I just add the namespace in your code and everything is working fine.