### PR TITLE
Autentication - Add expiration to the JWT tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- Security - Remove unnecessary leeway of 30s on JWTs.
 
 ## RELEASE 3.0.4 - 2019-05-21
 ### Fixed

--- a/app/controllers/forest_liana/application_controller.rb
+++ b/app/controllers/forest_liana/application_controller.rb
@@ -68,7 +68,7 @@ module ForestLiana
           end
 
           @jwt_decoded_token = JWT.decode(token, ForestLiana.auth_secret, true,
-            { algorithm: 'HS256', leeway: 30 }).try(:first)
+            { algorithm: 'HS256' }).try(:first)
           @rendering_id = @jwt_decoded_token['data']['relationships']['renderings']['data'][0]['id']
         else
           head :unauthorized


### PR DESCRIPTION
Remove unnecessary leeway of 30s on JWTs

https://trello.com/c/6P4KWrmE/3477-autentication-add-expiration-to-the-jwt-tokens