### PR TITLE
Support third party error logging via simple instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Functionality - Allow users to define their own error handling instrumentation for exceptions raised/rescued throughout the application.
+
 ## RELEASE 3.2.0 - 2019-07-22
 ### Added
 - Column Types - Support HSTORE column type.

--- a/app/controllers/forest_liana/application_controller.rb
+++ b/app/controllers/forest_liana/application_controller.rb
@@ -73,10 +73,12 @@ module ForestLiana
         else
           head :unauthorized
         end
-      rescue JWT::ExpiredSignature, JWT::VerificationError
+      rescue JWT::ExpiredSignature, JWT::VerificationError => error
+        report_exception(error)
         render json: { error: 'expired_token' }, status: :unauthorized,
           serializer: nil
-      rescue
+      rescue => error
+        report_exception(error)
         head :unauthorized
       end
     end
@@ -85,6 +87,7 @@ module ForestLiana
       begin
         params[:data][:attributes].values[0].to_hash.symbolize_keys
       rescue => error
+        report_exception(error)
         FOREST_LOGGER.error "Smart Action context retrieval error: #{error}"
         {}
       end

--- a/app/controllers/forest_liana/associations_controller.rb
+++ b/app/controllers/forest_liana/associations_controller.rb
@@ -18,6 +18,7 @@ module ForestLiana
           format.csv { render_csv(getter, @association.klass) }
         end
       rescue => error
+        report_exception(error)
         FOREST_LOGGER.error "Association Index error: #{error}\n#{format_stacktrace(error)}"
         internal_server_error
       end
@@ -30,6 +31,7 @@ module ForestLiana
 
         render serializer: nil, json: { count: getter.records_count }
       rescue => error
+        report_exception(error)
         FOREST_LOGGER.error "Association Index Count error: #{error}\n#{format_stacktrace(error)}"
         internal_server_error
       end
@@ -47,6 +49,7 @@ module ForestLiana
           head :no_content
         end
       rescue => error
+        report_exception(error)
         FOREST_LOGGER.error "Association Update error: #{error}\n#{format_stacktrace(error)}"
         internal_server_error
       end
@@ -59,6 +62,7 @@ module ForestLiana
 
         head :no_content
       rescue => error
+        report_exception(error)
         FOREST_LOGGER.error "Association Associate error: #{error}\n#{format_stacktrace(error)}"
         internal_server_error
       end
@@ -71,6 +75,7 @@ module ForestLiana
 
         head :no_content
       rescue => error
+        report_exception(error)
         FOREST_LOGGER.error "Association Associate error: #{error}\n#{format_stacktrace(error)}"
         internal_server_error
       end

--- a/app/controllers/forest_liana/base_controller.rb
+++ b/app/controllers/forest_liana/base_controller.rb
@@ -6,6 +6,10 @@ module ForestLiana
 
     private
 
+    def report_exception(error)
+      ForestLiana.error_handler.call(error) if ForestLiana.error_handler
+    end
+
     def reject_unauthorized_ip
       begin
         ip = request.remote_ip
@@ -20,12 +24,14 @@ module ForestLiana
           end
         end
       rescue ForestLiana::Errors::ExpectedError => exception
+        report_exception(exception)
         error_data = JSONAPI::Serializer.serialize_errors([{
           status: exception.error_code,
           detail: exception.message
         }])
         render(serializer: nil, json: error_data, status: exception.status)
       rescue => exception
+        report_exception(exception)
         FOREST_LOGGER.error(exception)
         FOREST_LOGGER.error(exception.backtrace.join("\n"))
         render(serializer: nil, json: nil, status: :internal_server_error)

--- a/app/controllers/forest_liana/resources_controller.rb
+++ b/app/controllers/forest_liana/resources_controller.rb
@@ -34,9 +34,11 @@ module ForestLiana
           format.csv { render_csv(getter, @resource) }
         end
       rescue ForestLiana::Errors::LiveQueryError => error
+        report_exception(error)
         render json: { errors: [{ status: 422, detail: error.message }] },
           status: :unprocessable_entity, serializer: nil
       rescue ForestLiana::Errors::ExpectedError => error
+        report_exception(error)
         error.display_error
         error_data = JSONAPI::Serializer.serialize_errors([{
           status: error.error_code,
@@ -44,6 +46,7 @@ module ForestLiana
         }])
         render(serializer: nil, json: error_data, status: error.status)
       rescue => error
+        report_exception(error)
         FOREST_LOGGER.error "Records Index error: #{error}\n#{format_stacktrace(error)}"
         internal_server_error
       end
@@ -60,9 +63,11 @@ module ForestLiana
         render serializer: nil, json: { count: getter.records_count }
 
       rescue ForestLiana::Errors::LiveQueryError => error
+        report_exception(error)
         render json: { errors: [{ status: 422, detail: error.message }] },
           status: :unprocessable_entity, serializer: nil
       rescue ForestLiana::Errors::ExpectedError => error
+        report_exception(error)
         error.display_error
         error_data = JSONAPI::Serializer.serialize_errors([{
           status: error.error_code,
@@ -70,6 +75,7 @@ module ForestLiana
         }])
         render(serializer: nil, json: error_data, status: error.status)
       rescue => error
+        report_exception(error)
         FOREST_LOGGER.error "Records Index Count error: #{error}\n#{format_stacktrace(error)}"
         internal_server_error
       end
@@ -85,6 +91,7 @@ module ForestLiana
 
         render serializer: nil, json: render_record_jsonapi(getter.record)
       rescue => error
+        report_exception(error)
         FOREST_LOGGER.error "Record Show error: #{error}\n#{format_stacktrace(error)}"
         internal_server_error
       end
@@ -108,6 +115,7 @@ module ForestLiana
             creator.record.errors), status: 400
         end
       rescue => error
+        report_exception(error)
         FOREST_LOGGER.error "Record Create error: #{error}\n#{format_stacktrace(error)}"
         internal_server_error
       end
@@ -131,6 +139,7 @@ module ForestLiana
             updater.record.errors), status: 400
         end
       rescue => error
+        report_exception(error)
         FOREST_LOGGER.error "Record Update error: #{error}\n#{format_stacktrace(error)}"
         internal_server_error
       end
@@ -144,6 +153,7 @@ module ForestLiana
         @resource.destroy(params[:id]) if @resource.exists?(params[:id])
         head :no_content
       rescue => error
+        report_exception(error)
         FOREST_LOGGER.error "Record Destroy error: #{error}\n#{format_stacktrace(error)}"
         internal_server_error
       end
@@ -160,6 +170,7 @@ module ForestLiana
           render serializer: nil, json: { status: 404 }, status: :not_found
         end
       rescue => error
+        report_exception(error)
         FOREST_LOGGER.error "Find Collection error: #{error}\n#{format_stacktrace(error)}"
         render serializer: nil, json: { status: 404 }, status: :not_found
       end

--- a/app/controllers/forest_liana/sessions_controller.rb
+++ b/app/controllers/forest_liana/sessions_controller.rb
@@ -70,6 +70,7 @@ module ForestLiana
         ).perform
 
       rescue ForestLiana::Errors::ExpectedError => error
+        report_exception(error)
         error.display_error
         error_data = JSONAPI::Serializer.serialize_errors([{
           status: error.error_code,
@@ -77,6 +78,7 @@ module ForestLiana
         }])
         render(serializer: nil, json: error_data, status: error.status)
       rescue StandardError => error
+        report_exception(error)
         FOREST_LOGGER.error error
         FOREST_LOGGER.error error.backtrace.join("\n")
 

--- a/app/controllers/forest_liana/stats_controller.rb
+++ b/app/controllers/forest_liana/stats_controller.rb
@@ -45,9 +45,11 @@ module ForestLiana
           render json: {status: 404}, status: :not_found, serializer: nil
         end
       rescue ForestLiana::Errors::LiveQueryError => error
+        report_exception(error)
         render json: { errors: [{ status: 422, detail: error.message }] },
           status: :unprocessable_entity, serializer: nil
       rescue => error
+        report_exception(error)
         FOREST_LOGGER.error "Live Query error: #{error.message}"
         render json: { errors: [{ status: 422, detail: error.message }] },
           status: :unprocessable_entity, serializer: nil

--- a/app/controllers/forest_liana/stripe_controller.rb
+++ b/app/controllers/forest_liana/stripe_controller.rb
@@ -32,6 +32,7 @@ module ForestLiana
 
         render serializer: nil, json: {}
       rescue ::Stripe::InvalidRequestError => error
+        report_exception(error)
         render serializer: nil, json: { error: error.message }, status: 400
       end
     end

--- a/app/deserializers/forest_liana/resource_deserializer.rb
+++ b/app/deserializers/forest_liana/resource_deserializer.rb
@@ -153,7 +153,8 @@ module ForestLiana
       begin
         Paperclip.io_adapters.handler_for(attr)
         true
-      rescue Paperclip::AdapterRegistry::NoHandlerError
+      rescue Paperclip::AdapterRegistry::NoHandlerError => exception
+        ForestLiana.error_handler.call(exception)
         false
       end
     end

--- a/app/helpers/forest_liana/decoration_helper.rb
+++ b/app/helpers/forest_liana/decoration_helper.rb
@@ -7,7 +7,8 @@ module ForestLiana
           match_fields[index] = { id: record['id'], search: [] } if match_fields[index].nil?
           match_fields[index][:search] << field_name
         end
-      rescue
+      rescue => exception
+        ForestLiana.error_handler.call(exception)
       end
     end
 

--- a/app/serializers/forest_liana/serializer_factory.rb
+++ b/app/serializers/forest_liana/serializer_factory.rb
@@ -123,7 +123,8 @@ module ForestLiana
                   ret[:href] = "/forest/#{ForestLiana.name_for(object.class)}/#{object.id}/relationships/#{attribute_name}"
                 end
               end
-            rescue TypeError, ActiveRecord::StatementInvalid, NoMethodError
+            rescue TypeError, ActiveRecord::StatementInvalid, NoMethodError => exception
+              ForestLiana.error_handler.call(exception)
               puts "Cannot load the association #{attribute_name} on #{object.class.name} #{object.id}."
             end
           end
@@ -176,7 +177,8 @@ module ForestLiana
           serializer.attribute(attribute) do |x|
             begin
               object.send(attribute)
-            rescue
+            rescue => exception
+              ForestLiana.error_handler.call(exception)
               nil
             end
           end
@@ -193,7 +195,8 @@ module ForestLiana
               else
                 nil
               end
-            rescue
+            rescue => exception
+              ForestLiana.error_handler.call(exception)
               nil
             end
           end
@@ -205,7 +208,8 @@ module ForestLiana
             begin
               value = object.send(attr)
               value ? value.to_json : nil
-            rescue
+            rescue => exception
+              ForestLiana.error_handler.call(exception)
               nil
             end
           end
@@ -217,7 +221,8 @@ module ForestLiana
             serializer.attribute(key) do |x|
               begin
                 object.send(key).try(:url)
-              rescue
+              rescue => exception
+                ForestLiana.error_handler.call(exception)
                 nil
               end
             end
@@ -230,7 +235,8 @@ module ForestLiana
             serializer.attribute(key) do |x|
               begin
                 object.send(key)
-              rescue
+              rescue => exception
+                ForestLiana.error_handler.call(exception)
                 nil
               end
             end
@@ -245,7 +251,8 @@ module ForestLiana
             serializer.attribute(key) do |x|
               begin
                 object.send(key).map(&:name)
-              rescue
+              rescue => exception
+                ForestLiana.error_handler.call(exception)
                 nil
               end
             end
@@ -266,7 +273,8 @@ module ForestLiana
                 if [:has_one, :belongs_to].include?(a.macro)
                   begin
                     object.send(a.name)
-                  rescue ActiveRecord::RecordNotFound
+                  rescue ActiveRecord::RecordNotFound => exception
+                    ForestLiana.error_handler.call(exception)
                     nil
                   end
                 else
@@ -274,7 +282,8 @@ module ForestLiana
                 end
               }
             end
-          rescue NameError
+          rescue NameError => exception
+            ForestLiana.error_handler.call(exception)
             # NOTICE: Let this error silent, a bad association warning will be
             # displayed in the schema adapter.
           end
@@ -407,10 +416,11 @@ module ForestLiana
     def foreign_keys(active_record_class)
       begin
         SchemaUtils.associations(active_record_class).map(&:foreign_key)
-      rescue => err
+      rescue => exception
+        ForestLiana.error_handler.call(exception)
         # Association foreign_key triggers an error. Put the stacktrace and
         # returns no foreign keys.
-        puts err.backtrace
+        puts exception.backtrace
         []
       end
     end

--- a/app/services/forest_liana/apimap_sorter.rb
+++ b/app/services/forest_liana/apimap_sorter.rb
@@ -93,6 +93,7 @@ module ForestLiana
         @apimap['meta'] = reorder_keys_basic(@apimap['meta'])
         @apimap
       rescue => exception
+        ForestLiana.error_handler.call(exception)
         FOREST_LOGGER.warn "An Apimap reordering issue occured: #{exception}"
         @apimap
       end

--- a/app/services/forest_liana/belongs_to_updater.rb
+++ b/app/services/forest_liana/belongs_to_updater.rb
@@ -18,8 +18,10 @@ module ForestLiana
 
         @record.save
       rescue ActiveRecord::SerializationTypeMismatch => exception
+        ForestLiana.error_handler.call(exception)
         @errors = [{ detail: exception.message }]
       rescue => exception
+        ForestLiana.error_handler.call(exception)
         @errors = [{ detail: exception.message }]
       end
     end

--- a/app/services/forest_liana/intercom_attributes_getter.rb
+++ b/app/services/forest_liana/intercom_attributes_getter.rb
@@ -18,6 +18,7 @@ module ForestLiana
         @record = user
       rescue Intercom::ResourceNotFound
       rescue Intercom::UnexpectedError => exception
+        ForestLiana.error_handler.call(exception)
         FOREST_LOGGER.error "Cannot retrieve the Intercom attributes: #{exception.message}"
       end
     end

--- a/app/services/forest_liana/intercom_conversation_getter.rb
+++ b/app/services/forest_liana/intercom_conversation_getter.rb
@@ -11,9 +11,11 @@ module ForestLiana
     def perform
       begin
         @record = @intercom.conversations.find(id: @params[:conversation_id])
-      rescue Intercom::ResourceNotFound
+      rescue Intercom::ResourceNotFound => exception
+        ForestLiana.error_handler.call(exception)
         @record = nil
       rescue Intercom::UnexpectedError => exception
+        ForestLiana.error_handler.call(exception)
         FOREST_LOGGER.error "Cannot retrieve the Intercom conversation: #{exception.message}"
         @record = nil
       end

--- a/app/services/forest_liana/intercom_conversations_getter.rb
+++ b/app/services/forest_liana/intercom_conversations_getter.rb
@@ -28,9 +28,11 @@ module ForestLiana
           type: 'user',
           display_as: 'plaintext',
         ).entries
-      rescue Intercom::ResourceNotFound
+      rescue Intercom::ResourceNotFound => exception
+        ForestLiana.error_handler.call(exception)
         @records = []
       rescue Intercom::UnexpectedError => exception
+        ForestLiana.error_handler.call(exception)
         FOREST_LOGGER.error "Cannot retrieve the Intercom conversations: #{exception.message}"
         @records = []
       end

--- a/app/services/forest_liana/ip_whitelist.rb
+++ b/app/services/forest_liana/ip_whitelist.rb
@@ -21,6 +21,7 @@ module ForestLiana
           false
         end
       rescue => exception
+        ForestLiana.error_handler.call(exception)
         FOREST_LOGGER.error 'Cannot retrieve the IP Whitelist from the Forest server.'
         FOREST_LOGGER.error 'Which was caused by:'
         ForestLiana::Errors::ExceptionHelper.recursively_print(exception, margin: ' ', is_error: true)

--- a/app/services/forest_liana/permissions_getter.rb
+++ b/app/services/forest_liana/permissions_getter.rb
@@ -16,6 +16,7 @@ module ForestLiana
           raise "Forest API returned an #{ForestLiana::Errors::HTTPErrorHelper.format(response)}"
         end
       rescue => exception
+        ForestLiana.error_handler.call(exception)
         FOREST_LOGGER.error 'Cannot retrieve the permissions from the Forest server.'
         FOREST_LOGGER.error 'Which was caused by:'
         ForestLiana::Errors::ExceptionHelper.recursively_print(exception, margin: ' ', is_error: true)

--- a/app/services/forest_liana/resource_creator.rb
+++ b/app/services/forest_liana/resource_creator.rb
@@ -18,11 +18,14 @@ module ForestLiana
         end
         set_has_many_relationships
       rescue ActiveRecord::StatementInvalid => exception
+        ForestLiana.error_handler.call(exception)
         # NOTICE: SQL request cannot be executed properly
         @errors = [{ detail: exception.cause.error }]
       rescue ForestLiana::Errors::SerializeAttributeBadFormat => exception
+        ForestLiana.error_handler.call(exception)
         @errors = [{ detail: exception.message }]
       rescue => exception
+        ForestLiana.error_handler.call(exception)
         @errors = [{ detail: exception.message }]
       end
     end

--- a/app/services/forest_liana/resource_updater.rb
+++ b/app/services/forest_liana/resource_updater.rb
@@ -19,11 +19,14 @@ module ForestLiana
           @record.update_attributes(resource_params, without_protection: true)
         end
       rescue ActiveRecord::StatementInvalid => exception
+        ForestLiana.error_handler.call(exception)
         # NOTICE: SQL request cannot be executed properly
         @errors = [{ detail: exception.cause.error }]
       rescue ForestLiana::Errors::SerializeAttributeBadFormat => exception
+        ForestLiana.error_handler.call(exception)
         @errors = [{ detail: exception.message }]
       rescue => exception
+        ForestLiana.error_handler.call(exception)
         @errors = [{ detail: exception.message }]
       end
     end

--- a/app/services/forest_liana/schema_adapter.rb
+++ b/app/services/forest_liana/schema_adapter.rb
@@ -257,10 +257,12 @@ module ForestLiana
           else
             collection.fields << get_schema_for_association(association)
           end
-        rescue NameError
+        rescue NameError => exception
+          ForestLiana.error_handler.call(exception)
           FOREST_LOGGER.warn "The association \"#{association.name.to_s}\" " \
             "does not seem to exist for model \"#{@model.name}\"."
         rescue => exception
+          ForestLiana.error_handler.call(exception)
           FOREST_LOGGER.error "An error occured trying to add " \
             "\"#{association.name.to_s}\" association:\n#{exception}"
         end

--- a/app/services/forest_liana/schema_utils.rb
+++ b/app/services/forest_liana/schema_utils.rb
@@ -99,7 +99,8 @@ module ForestLiana
 
           return inheritance_column.present?
         end
-      rescue NoMethodError
+      rescue NoMethodError => exception
+        ForestLiana.error_handler.call(exception)
         # NOTICE: ActiveRecord::Base throw the exception "undefined method
         # `abstract_class?' for Object:Class" when calling the existing method
         # "table_name".

--- a/app/services/forest_liana/search_query_builder.rb
+++ b/app/services/forest_liana/search_query_builder.rb
@@ -26,6 +26,7 @@ module ForestLiana
             begin
               @records = field[:search].call(@records, @search)
             rescue => exception
+              ForestLiana.error_handler.call(exception)
               FOREST_LOGGER.error "Cannot search properly on Smart Field:\n" \
                 "#{exception}"
             end

--- a/app/services/forest_liana/stripe_invoices_getter.rb
+++ b/app/services/forest_liana/stripe_invoices_getter.rb
@@ -49,7 +49,8 @@ module ForestLiana
 
           d
         end
-      rescue ::Stripe::InvalidRequestError => error
+      rescue ::Stripe::InvalidRequestError => exception
+        ForestLiana.error_handler.call(exception)
         FOREST_LOGGER.error "Stripe error: #{error.message}"
         @records = []
       end

--- a/app/services/forest_liana/stripe_payments_getter.rb
+++ b/app/services/forest_liana/stripe_payments_getter.rb
@@ -47,8 +47,9 @@ module ForestLiana
 
           d
         end
-      rescue ::Stripe::InvalidRequestError => error
-        FOREST_LOGGER.error "Stripe error: #{error.message}"
+      rescue ::Stripe::InvalidRequestError => exception
+        ForestLiana.error_handler.call(exception)
+        FOREST_LOGGER.error "Stripe error: #{exception.message}"
         @records = []
       end
     end

--- a/app/services/forest_liana/stripe_sources_getter.rb
+++ b/app/services/forest_liana/stripe_sources_getter.rb
@@ -45,8 +45,9 @@ module ForestLiana
 
           d
         end
-      rescue ::Stripe::InvalidRequestError => error
-        FOREST_LOGGER.error "Stripe error: #{error.message}"
+      rescue ::Stripe::InvalidRequestError => exception
+        ForestLiana.error_handler.call(exception)
+        FOREST_LOGGER.error "Stripe error: #{exception.message}"
         @records = []
       end
     end

--- a/app/services/forest_liana/stripe_subscriptions_getter.rb
+++ b/app/services/forest_liana/stripe_subscriptions_getter.rb
@@ -42,8 +42,9 @@ module ForestLiana
 
           d
         end
-      rescue ::Stripe::InvalidRequestError => error
-        FOREST_LOGGER.error "Stripe error: #{error.message}"
+      rescue ::Stripe::InvalidRequestError => exception
+        ForestLiana.error_handler.call(exception)
+        FOREST_LOGGER.error "Stripe error: #{exception.message}"
         @records = []
       end
     end

--- a/config/initializers/errors.rb
+++ b/config/initializers/errors.rb
@@ -89,7 +89,8 @@ module ForestLiana
 
       def self.try_parse_json(data)
         data.to_json
-      rescue JSON::ParserError
+      rescue JSON::ParserError => exception
+        ForestLiana.error_handler.call(exception)
         return nil
       end
     end

--- a/lib/forest_liana.rb
+++ b/lib/forest_liana.rb
@@ -25,6 +25,8 @@ module ForestLiana
   mattr_accessor :user_class_name
   mattr_accessor :names_overriden
   mattr_accessor :meta
+  mattr_accessor :error_handler
+
   # TODO: Remove once lianas prior to 2.0.0 are not supported anymore.
   mattr_accessor :names_old_overriden
 
@@ -60,3 +62,6 @@ module ForestLiana
     self.name_for(model).classify
   end
 end
+
+# Define an empty error handler
+ForestLiana.error_handler = ->(error) { }

--- a/lib/forest_liana.rb
+++ b/lib/forest_liana.rb
@@ -25,7 +25,11 @@ module ForestLiana
   mattr_accessor :user_class_name
   mattr_accessor :names_overriden
   mattr_accessor :meta
-  mattr_accessor :error_handler
+  mattr_accessor :error_handler do
+    # Defaults to an empty proc taking one argument.
+    # Override with a Proc/Lambda or a object that defines `call`
+    Proc.new { |exception| nil }
+  end
 
   # TODO: Remove once lianas prior to 2.0.0 are not supported anymore.
   mattr_accessor :names_old_overriden
@@ -62,6 +66,3 @@ module ForestLiana
     self.name_for(model).classify
   end
 end
-
-# Define an empty error handler
-ForestLiana.error_handler = ->(error) { }

--- a/lib/forest_liana/bootstraper.rb
+++ b/lib/forest_liana/bootstraper.rb
@@ -53,7 +53,8 @@ module ForestLiana
             content = JSON.parse(File.read(SCHEMA_FILENAME))
             @collections_sent = content['collections']
             @meta_sent = content['meta']
-          rescue JSON::JSONError
+          rescue JSON::JSONError => exception
+            ForestLiana.error_handler.call(exception)
             FOREST_LOGGER.error "The content of .forestadmin-schema.json file is not a correct JSON."
             FOREST_LOGGER.error "The schema cannot be synchronized with Forest Admin servers."
           end
@@ -93,6 +94,7 @@ module ForestLiana
           end
         end
       rescue => exception
+        ForestLiana.error_handler.call(exception)
         FOREST_LOGGER.error "Cannot fetch properly model #{model.name}:\n" \
           "#{exception}"
       end
@@ -289,9 +291,11 @@ module ForestLiana
                 "contact support@forestadmin.com for further investigations."
             end
           end
-        rescue Errno::ECONNREFUSED, SocketError
+        rescue Errno::ECONNREFUSED, SocketError => exception
+          ForestLiana.error_handler.call(exception)
           FOREST_LOGGER.warn "Cannot send the apimap to Forest. Are you online?"
-        rescue
+        rescue => exception
+          ForestLiana.error_handler.call(exception)
           FOREST_LOGGER.warn "Cannot send the apimap to Forest. Forest might " \
             "currently be in maintenance."
         end
@@ -634,7 +638,8 @@ module ForestLiana
         else
           connection.instance_values['config'][:adapter]
         end
-      rescue
+      rescue => exception
+        ForestLiana.error_handler.call(exception)
         'unknown'
       end
     end

--- a/lib/forest_liana/collection.rb
+++ b/lib/forest_liana/collection.rb
@@ -91,6 +91,7 @@ module ForestLiana::Collection
               begin
                 object.instance_eval(&block)
               rescue => exception
+                ForestLiana.error_handler.call(exception)
                 FOREST_LOGGER.error "Cannot retrieve the " + name.to_s + " value because of an " \
                   "internal error in the getter implementation: " + exception.message
                 nil

--- a/lib/forest_liana/engine.rb
+++ b/lib/forest_liana/engine.rb
@@ -28,6 +28,7 @@ module ForestLiana
         end
         nil
       rescue => exception
+        ForestLiana.error_handler.call(exception)
         exception
       end
     end
@@ -40,9 +41,10 @@ module ForestLiana
       database_available = true
       begin
         ActiveRecord::Base.connection_pool.with_connection { |connection| connection.active? }
-      rescue => error
+      rescue => exception
+        ForestLiana.error_handler.call(exception)
         database_available = false
-        FOREST_LOGGER.error "No Apimap sent to Forest servers, it seems that the database is not accessible:\n#{error}"
+        FOREST_LOGGER.error "No Apimap sent to Forest servers, it seems that the database is not accessible:\n#{exception}"
       end
       database_available
     end

--- a/test/forest_liana_test.rb
+++ b/test/forest_liana_test.rb
@@ -4,4 +4,8 @@ class ForestLianaTest < ActiveSupport::TestCase
   test "truth" do
     assert_kind_of Module, ForestLiana
   end
+
+  test "error_handler is a proc" do
+    assert_kind_of Proc, ForestLiana.error_handler
+  end
 end


### PR DESCRIPTION
Hi,

Being able to report exceptions to a third party tool is a common fallback in a lot of Ruby and Ruby on Rails projects. In our case we use Sentry to manage error fallout and monitoring, but we discovered recently that a large amount of Forest related errors were being swallowed and reported only in the logs. This issue has been raised previously here: https://github.com/ForestAdmin/forest-rails/issues/178 but without any follow up.

This MR attempts to provide a very simple interface for bubbling errors out of the Forest application. It is set explicitly whenever Forest rescue's an error but does not raise a new one. By default it will do nothing with the exception, and it is up to the user to override that default behaviour.

Here are the ways you'd report the error to either Sentry or Airbrake, two very popular error monitoring tools.

```ruby
# Sentry
ForestLiana.error_handler = ->(exception) { Raven.capture_exception(exception) }
# Airbrake
ForestLiana.error_handler = ->(exception) { Airbrake.notify(exception) }
```

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request
- [x] Write changes made in the CHANGELOG.md
- [ ] Create automatic tests
- [x] No automatic tests failures
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
