### PR TITLE
Add initialisation of configuration directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- Configuration - Add initialisation of configuration directories
+
 ### Changed
 - Readme - Add a community section.
 - Readme - Remove the Licence section as it is already accessible in the Github page header.

--- a/lib/forest_liana.rb
+++ b/lib/forest_liana.rb
@@ -37,8 +37,18 @@ module ForestLiana
   self.names_overriden = {}
   self.meta = {}
 
+  @config_dir = 'lib/forest_liana/**/*.rb'
+
   # TODO: Remove once lianas prior to 2.0.0 are not supported anymore.
   self.names_old_overriden = {}
+
+  def self.config_dir=(config_dir)
+    @config_dir = config_dir
+  end
+
+  def self.config_dir
+    Rails.root.join(@config_dir)
+  end
 
   def self.schema_for_resource resource
     self.apimap.find do |collection|

--- a/lib/forest_liana/bootstraper.rb
+++ b/lib/forest_liana/bootstraper.rb
@@ -211,8 +211,7 @@ module ForestLiana
     end
 
     def require_lib_forest_liana
-      path = Rails.root.join('lib', 'forest_liana', '**', '*.rb')
-      Dir.glob(File.expand_path(path, __FILE__)).each do |file|
+      Dir.glob(ForestLiana.config_dir).each do |file|
         load file
       end
     end

--- a/test/forest_liana_test.rb
+++ b/test/forest_liana_test.rb
@@ -4,4 +4,22 @@ class ForestLianaTest < ActiveSupport::TestCase
   test "truth" do
     assert_kind_of Module, ForestLiana
   end
+
+  test 'config_dirs with no value set' do
+    assert_equal(
+      Rails.root.join('lib/forest_liana/**/*.rb'),
+      ForestLiana.config_dir
+    )
+  end
+
+  test 'config_dirs with a value set' do
+    ForestLiana.config_dir = 'lib/custom/**/*.rb'
+
+    assert_equal(
+      Rails.root.join('lib/custom/**/*.rb'),
+      ForestLiana.config_dir
+    )
+
+    ForestLiana.config_dir = nil
+  end
 end


### PR DESCRIPTION
We had hardcoded the directory used for configuring more data models. Hardcoding this value made it difficult to set a custom directory to define these files. It also caused `zeitwerk` to throw a warning when trying to autoload the extra classes. We added a `config_dirs` accessor to the configuration module. Adding this attribute allows us to set this directory ourselves.

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request
- [x] Write changes made in the CHANGELOG.md
- [x] Create automatic tests
- [x] No automatic tests failures
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
