### PR TITLE
Fix: Check serializer in ForestLiana::UserSpace module only

### DIFF
--- a/app/serializers/forest_liana/serializer_factory.rb
+++ b/app/serializers/forest_liana/serializer_factory.rb
@@ -6,7 +6,7 @@ module ForestLiana
     def self.define_serializer(active_record_class, serializer)
       serializer_name = self.build_serializer_name(active_record_class)
 
-      if ForestLiana::UserSpace.const_defined?(serializer_name)
+      if ForestLiana::UserSpace.const_defined?(serializer_name, false)
         ForestLiana::UserSpace.send(:remove_const, serializer_name)
       end
 


### PR DESCRIPTION
The app could already have a PostSerializer (for instance) globally defined (for instance if the app is using JSON serializers outside of ForestAdmin).
When this is the case, this gem tries to remove the constant (`ForestLiana::UserSpace.send(:remove_const, serializer_name)`) from ForestLiana::UserSpace module but 1/ it isn't there and 2/ it should not remove it.

https://ruby-doc.org/core-2.6.4/Module.html#method-i-const_defined-3F

## Pull Request checklist:

- [ ] Write an explicit title for the Pull Request
- [ ] Write changes made in the CHANGELOG.md
- [ ] Create automatic tests
- [ ] No automatic tests failures
- [ ] Test manually the implemented changes
- [ ] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code
