### PR TITLE
[*] Stripe Integration - Replace usage of the deprecated `all` function by the `list` one from stripe gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Fixed
+- Stripe Integration - Remove usage of the deprecated `all` function from stripe gem.
 
 ## RELEASE 4.1.2 - 2019-11-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
-- Stripe Integration - Remove usage of the deprecated `all` function from stripe gem.
+- Stripe Integration - Fix Stripe collections display with latest Stripe gem versions.
 
 ## RELEASE 4.1.2 - 2019-11-15
 ### Fixed

--- a/app/services/forest_liana/stripe_invoices_getter.rb
+++ b/app/services/forest_liana/stripe_invoices_getter.rb
@@ -57,7 +57,7 @@ module ForestLiana
 
     def fetch_invoices(params)
       return if @params[:id] && params[:customer].blank?
-      ::Stripe::Invoice.all(params)
+      ::Stripe::Invoice.list(params)
     end
 
     def starting_after

--- a/app/services/forest_liana/stripe_payments_getter.rb
+++ b/app/services/forest_liana/stripe_payments_getter.rb
@@ -55,7 +55,7 @@ module ForestLiana
 
     def fetch_charges(params)
       return if @params[:id] && params[:customer].blank?
-      ::Stripe::Charge.all(params)
+      ::Stripe::Charge.list(params)
     end
 
     def starting_after

--- a/app/services/forest_liana/stripe_sources_getter.rb
+++ b/app/services/forest_liana/stripe_sources_getter.rb
@@ -32,7 +32,7 @@ module ForestLiana
 
     def fetch_bank_accounts(customer, params)
       begin
-        @cards = ::Stripe::Customer.retrieve(customer).sources.all(params)
+        @cards = ::Stripe::Customer.retrieve(customer).sources.list(params)
         if @cards.blank?
           @records = []
           return

--- a/app/services/forest_liana/stripe_subscriptions_getter.rb
+++ b/app/services/forest_liana/stripe_subscriptions_getter.rb
@@ -50,7 +50,7 @@ module ForestLiana
 
     def fetch_subscriptions(params)
       return if @params[:id] && params[:customer].blank?
-      ::Stripe::Subscription.all(params)
+      ::Stripe::Subscription.list(params)
     end
 
     def starting_after


### PR DESCRIPTION


Fixes deprecated usage of the `all` function. 

Support stopped following this PR: https://github.com/stripe/stripe-ruby/pull/823/files