### PR TITLE
[*] Technical - Fix CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 before_install:
-  -  gem install bundler -v '1.17.3'
+  - gem install bundler -v '1.17.3'
 rvm:
   - 2.3.4
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
 language: ruby
 before_install:
-  - gem update bundler
+  -  gem uninstall bundler
+  -  gem install bundler -v '1.17.3'
 rvm:
   - 2.3.4
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 before_install:
-  -  gem uninstall bundler
   -  gem install bundler -v '1.17.3'
 rvm:
   - 2.3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Fixed
+- Technical - Fix bundler version
 
 ## RELEASE 4.1.3 - 2019-12-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
-- Technical - Fix bundler version
+- Technical - Fix CI build.
 
 ## RELEASE 4.1.3 - 2019-12-04
 ### Fixed


### PR DESCRIPTION
Currently, Travis pulls the latest version of the bundler, whereas in our gemfile.lock, it is specified that the `1.17.3` is required.