### PR TITLE
[+] Resources getter - Add a get_ids_from_request method to get all models IDs given a query or an ID list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- Resources getter - Add a get_ids_from_request method to get all models IDs given a query or an ID list.
+- Resource Deletion - Users can now bulk delete records.
 
 ## RELEASE 4.2.0 - 2020-01-22
 ### Added

--- a/app/controllers/forest_liana/resources_controller.rb
+++ b/app/controllers/forest_liana/resources_controller.rb
@@ -137,23 +137,28 @@ module ForestLiana
     end
 
     def destroy
-      begin
-        checker = ForestLiana::PermissionsChecker.new(@resource, 'delete', @rendering_id)
-        return head :forbidden unless checker.is_authorized?
+      checker = ForestLiana::PermissionsChecker.new(@resource, 'delete', @rendering_id)
+      return head :forbidden unless checker.is_authorized?
 
-        # NOTICE: destroy one or many records.
-        if (params[:id] && params.dig('data', 'attributes') == nil)
-          @resource.destroy(params[:id]) if @resource.exists?(params[:id])
-        else 
-          ids = ForestLiana::ResourcesGetter.get_ids_from_request(params)
-          @resource.destroy(ids)
-        end
-        
-        head :no_content
-      rescue => error
-        FOREST_LOGGER.error "Record Destroy error: #{error}\n#{format_stacktrace(error)}"
-        internal_server_error
-      end
+      @resource.destroy(params[:id]) if @resource.exists?(params[:id])
+
+      head :no_content
+    rescue => error
+      FOREST_LOGGER.error "Record Destroy error: #{error}\n#{format_stacktrace(error)}"
+      internal_server_error
+    end
+
+    def destroy_many
+      checker = ForestLiana::PermissionsChecker.new(@resource, 'delete', @rendering_id)
+      return head :forbidden unless checker.is_authorized?
+
+      ids = ForestLiana::ResourcesGetter.get_ids_from_request(params)
+      @resource.destroy(ids) if ids&.any?
+
+      head :no_content
+    rescue => error
+      FOREST_LOGGER.error "Records Destroy error: #{error}\n#{format_stacktrace(error)}"
+      internal_server_error
     end
 
     private

--- a/app/controllers/forest_liana/resources_controller.rb
+++ b/app/controllers/forest_liana/resources_controller.rb
@@ -141,7 +141,14 @@ module ForestLiana
         checker = ForestLiana::PermissionsChecker.new(@resource, 'delete', @rendering_id)
         return head :forbidden unless checker.is_authorized?
 
-        @resource.destroy(params[:id]) if @resource.exists?(params[:id])
+        # NOTICE: destroy one or many records.
+        if (params[:id] && params.dig('data', 'attributes') == nil)
+          @resource.destroy(params[:id]) if @resource.exists?(params[:id])
+        else 
+          ids = ForestLiana::ResourcesGetter.get_ids_from_request(params)
+          @resource.destroy(ids)
+        end
+        
         head :no_content
       rescue => error
         FOREST_LOGGER.error "Record Destroy error: #{error}\n#{format_stacktrace(error)}"

--- a/app/controllers/forest_liana/router.rb
+++ b/app/controllers/forest_liana/router.rb
@@ -30,7 +30,11 @@ class ForestLiana::Router
         when 'POST'
           action = 'create'
         when 'DELETE'
-          action = 'destroy'
+          if params[:id]
+            action = 'destroy'
+          else
+            action = 'destroy_many'
+          end
         end
 
         controller.action(action.to_sym).call(env)

--- a/app/services/forest_liana/has_many_dissociator.rb
+++ b/app/services/forest_liana/has_many_dissociator.rb
@@ -14,10 +14,12 @@ module ForestLiana
 
       remove_association = !@with_deletion || @association.macro == :has_and_belongs_to_many
 
-      if @data.is_a?(Array) && @data.dig('attributes').nil?
+      if @data.is_a?(Array)
         record_ids = @data.map { |record| record[:id] }
-      elsif !@data.dig('attributes').nil?
+      elsif @data.dig('attributes').present?
         record_ids = ForestLiana::ResourcesGetter.get_ids_from_request(@params)
+      else
+        record_ids = Array.new
       end
 
       if !record_ids.nil? && record_ids.any?

--- a/app/services/forest_liana/has_many_dissociator.rb
+++ b/app/services/forest_liana/has_many_dissociator.rb
@@ -14,20 +14,31 @@ module ForestLiana
 
       remove_association = !@with_deletion || @association.macro == :has_and_belongs_to_many
 
+      record_ids = Array.new
+
       if remove_association
-        if @data.is_a?(Array)
-          @data.each do |record_deleted|
-            associated_records.delete(@association.klass.find(record_deleted[:id]))
+        if @data.is_a?(Array) && @data.dig('attributes') == nil
+          record_ids = @data.map { |record| record[:id] }
+        elsif @data.dig('attributes') != nil
+          record_ids = ForestLiana::ResourcesGetter.get_ids_from_request(@params)
+        end
+        if record_ids.any?
+          record_ids.each do |id|
+            associated_records.delete(@association.klass.find(id))
           end
         end
       end
 
       if @with_deletion
-        if @data.is_a?(Array)
+        if @data.is_a?(Array) && @data.dig('attributes') == nil
           record_ids = @data.map { |record| record[:id] }
+        elsif @data.dig('attributes') != nil
+          record_ids = ForestLiana::ResourcesGetter.get_ids_from_request(@params)
+        end
+        if record_ids.any?
           record_ids = record_ids.select { |record_id| @association.klass.exists?(record_id) }
           @association.klass.destroy(record_ids)
-        end
+        end 
       end
     end
   end

--- a/app/services/forest_liana/has_many_dissociator.rb
+++ b/app/services/forest_liana/has_many_dissociator.rb
@@ -14,31 +14,23 @@ module ForestLiana
 
       remove_association = !@with_deletion || @association.macro == :has_and_belongs_to_many
 
-      record_ids = Array.new
+      if @data.is_a?(Array) && @data.dig('attributes').nil?
+        record_ids = @data.map { |record| record[:id] }
+      elsif !@data.dig('attributes').nil?
+        record_ids = ForestLiana::ResourcesGetter.get_ids_from_request(@params)
+      end
 
-      if remove_association
-        if @data.is_a?(Array) && @data.dig('attributes') == nil
-          record_ids = @data.map { |record| record[:id] }
-        elsif @data.dig('attributes') != nil
-          record_ids = ForestLiana::ResourcesGetter.get_ids_from_request(@params)
-        end
-        if record_ids.any?
+      if !record_ids.nil? && record_ids.any?
+        if remove_association
           record_ids.each do |id|
             associated_records.delete(@association.klass.find(id))
           end
         end
-      end
 
-      if @with_deletion
-        if @data.is_a?(Array) && @data.dig('attributes') == nil
-          record_ids = @data.map { |record| record[:id] }
-        elsif @data.dig('attributes') != nil
-          record_ids = ForestLiana::ResourcesGetter.get_ids_from_request(@params)
-        end
-        if record_ids.any?
+        if @with_deletion
           record_ids = record_ids.select { |record_id| @association.klass.exists?(record_id) }
           @association.klass.destroy(record_ids)
-        end 
+        end
       end
     end
   end

--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -30,6 +30,9 @@ module ForestLiana
       # NOTICE: If it is a "select all records" we have to perform query to build ID list.
       ids = Array.new
 
+      # NOTICE: Merging all_records_subset_query into attributes preserves filters in HasManyGetter and ResourcesGetter.
+      attributes = attributes.merge(attributes[:all_records_subset_query].dup.to_unsafe_h)
+
       # NOTICE: Initialize actual resources getter (could either a HasManyGetter or a ResourcesGetter).
       is_related_data = attributes[:parent_collection_id] &&
         attributes[:parent_collection_name] &&

--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -21,8 +21,8 @@ module ForestLiana
 
     def self.get_ids_from_request(params)
       attributes = params.dig('data', 'attributes')
-      has_body_attributes = attributes === nil
-      is_select_all_records_query = has_body_attributes && attributes.all_records === true
+      has_body_attributes = attributes != nil
+      is_select_all_records_query = has_body_attributes && attributes[:all_records] === true
     
     
       # NOTICE: If it is not a "select all records" query and it receives a list of ID.

--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -19,6 +19,27 @@ module ForestLiana
       prepare_query()
     end
 
+    def self.get_ids_from_request(params)
+      attributes = params.dig('data', 'attributes')
+      has_body_attributes = attributes === nil
+      is_select_all_records_query = has_body_attributes && attributes.all_records === true
+    
+    
+      # NOTICE: If it is not a "select all records" query and it receives a list of ID.
+      if (!is_select_all_records_query && attributes[:ids])
+        return attributes[:ids]
+      end
+    
+      collection_name = attributes[:collection_name]
+      model = ForestLiana::SchemaUtils.find_model_from_collection_name(collection_name)
+      resources_getter = ForestLiana::ResourcesGetter.new(model, attributes)
+      resources = Array.new
+      resources_getter.query_for_batch.find_in_batches() do |records|
+        resources += records.map { |record| record.id }
+      end
+      return resources
+    end
+
     def perform
       @records = @records.eager_load(@includes)
     end

--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -22,9 +22,8 @@ module ForestLiana
     def self.get_ids_from_request(params)
       attributes = params.dig('data', 'attributes')
       has_body_attributes = attributes != nil
-      is_select_all_records_query = has_body_attributes && attributes[:all_records] === true
-    
-    
+      is_select_all_records_query = has_body_attributes && attributes[:all_records] == true
+
       # NOTICE: If it is not a "select all records" query and it receives a list of ID, return list of ID.
       return attributes[:ids] if (!is_select_all_records_query && attributes[:ids])
 
@@ -32,17 +31,17 @@ module ForestLiana
       ids = Array.new
 
       # NOTICE: Initialize actual resources getter (could either a HasManyGetter or a ResourcesGetter).
-      isRelatedData = attributes[:parent_collection_id] &&
+      is_related_data = attributes[:parent_collection_id] &&
         attributes[:parent_collection_name] &&
         attributes[:parent_association_name]
-      if (isRelatedData)
+      if is_related_data
         parent_collection_name = attributes[:parent_collection_name]
         parent_model = ForestLiana::SchemaUtils.find_model_from_collection_name(parent_collection_name)
         model = parent_model.reflect_on_association(attributes[:parent_association_name].try(:to_sym))
-        resources_getter = ForestLiana::HasManyGetter.new(parent_model, model, attributes.merge({ 
-          id: attributes[:parent_collection_id], 
-          association_name: attributes[:parent_association_name], 
-          collection: parent_collection_name
+        resources_getter = ForestLiana::HasManyGetter.new(parent_model, model, attributes.merge({
+          collection: parent_collection_name,
+          id: attributes[:parent_collection_id],
+          association_name: attributes[:parent_association_name],
         }))
       else
         collection_name = attributes[:collection_name]
@@ -50,7 +49,7 @@ module ForestLiana
         resources_getter = ForestLiana::ResourcesGetter.new(model, attributes)
       end
 
-      # NOTICE: build ID list.
+      # NOTICE: build IDs list.
       resources_getter.query_for_batch.find_in_batches() do |records|
         ids += records.map { |record| record.id }
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ ForestLiana::Engine.routes.draw do
   post ':collection', to: router
   put ':collection/:id', to: router
   delete ':collection/:id', to: router
+  delete ':collection', to: router
 
   # Smart Actions forms value
   post 'actions/:action_name/values' => 'actions#values'


### PR DESCRIPTION
Add "select all records" mode for rails liana. See: https://app.clickup.com/t/3rhj80

## Usage in smart actions

```ruby
class Forest::ActorsController < ForestLiana::ApplicationController
  def mark_as_live
    actor_ids = ForestLiana::ResourcesGetter.get_ids_from_request(params)

    # do something.

    render json: { success: 'Data successfuly imported!' }
  end
end
```

## How to test

You have ton use this branch as a dependency in `Gemfile`
```
gem 'forest_liana', path: '../forest-rails'
```

Then you have to update `forestadmin` [liana feature file](https://github.com/ForestAdmin/forestadmin/blob/5c97aa9392c278b9aed616f1ea60086c7e11f4bf/app/services/liana-features.js) to enable "select all" feature:

```javascript
{
  name: 'tableViewSelectAllRecords',
  minimalVersion: {
    'forest-express-sequelize': '6.0.0',
    'forest-express-mongoose': '6.0.0',
    'forest-rails': '4.2.0', // <- use this version
  },
}
```

## TODO list
 - [x] implement `get_ids_from_request`
   - [x] It should still work for id lists
   - [x] it should work for all records
   - [x] it should consider excluded ids
   - [x] it should work for nested collections
- [x] implement delete bulk
   - [x] it should work for nested collections (disociation
   - [x] it should work for nested collections (deletion)
   - [x] it should work for collection

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request
- [x] Write changes made in the CHANGELOG.md
- [ ] Create automatic tests
- [x] No automatic tests failures
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code

## Important note

⚠️  The code I wrote is ugly, inconsistant, tinkered and flawes: feel free to suggest (or even commit) better code.