### PR TITLE
[*] Has Many Relationships - Fix records count, i.e consider filters when counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Fixed
+- Has Many Relationships - Fix records count, i.e consider filters when counting.
 
 ## RELEASE 4.2.0 - 2020-01-22
 ### Added

--- a/app/services/forest_liana/has_many_getter.rb
+++ b/app/services/forest_liana/has_many_getter.rb
@@ -19,11 +19,11 @@ module ForestLiana
     end
 
     def perform
-      @records = @search_query_builder.perform(@records)
+      @records
     end
 
     def count
-      @records_count = @search_query_builder.perform(@records).count
+      @records_count = @records.count
     end
 
     def query_for_batch
@@ -64,10 +64,12 @@ module ForestLiana
     end
 
     def prepare_query
-      @records = get_resource()
-        .find(@params[:id])
-        .send(@params[:association_name])
-        .eager_load(@includes)
+      @records = @search_query_builder.perform(
+        get_resource()
+          .find(@params[:id])
+          .send(@params[:association_name])
+          .eager_load(@includes)
+      )
     end
 
     def offset

--- a/app/services/forest_liana/has_many_getter.rb
+++ b/app/services/forest_liana/has_many_getter.rb
@@ -23,7 +23,7 @@ module ForestLiana
     end
 
     def count
-      @records_count = @records.count
+      @records_count = @search_query_builder.perform(@records).count
     end
 
     def query_for_batch


### PR DESCRIPTION
## Description

See @SteveBunlon's comment: https://github.com/ForestAdmin/forest-rails/pull/345#issuecomment-592613766

> When I filter the related data, the count is not correct (see at the bottom right of the screen)

This PR consider filters before counting related data.

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request
- [x] Write changes made in the CHANGELOG.md
- [ ] Create automatic tests
- [x] No automatic tests failures
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
