### PR TITLE
Fix: stripe_invoices_getter.rb, stripe_invoice_serializer.rb

### DIFF
--- a/app/serializers/forest_liana/stripe_invoice_serializer.rb
+++ b/app/serializers/forest_liana/stripe_invoice_serializer.rb
@@ -3,20 +3,21 @@ module ForestLiana
     include JSONAPI::Serializer
 
     attribute :amount_due
+    attribute :amount_paid
+    attribute :amount_remaining
+    attribute :application_fee_amount
     attribute :attempt_count
     attribute :attempted
-    attribute :closed
     attribute :currency
     attribute :date
-    attribute :forgiven
+    attribute :due_date
     attribute :paid
     attribute :period_end
     attribute :period_start
+    attribute :status
     attribute :subtotal
     attribute :total
-    attribute :application_fee
     attribute :tax
-    attribute :tax_percent
 
     has_one :customer
 

--- a/app/services/forest_liana/stripe_invoices_getter.rb
+++ b/app/services/forest_liana/stripe_invoices_getter.rb
@@ -32,7 +32,7 @@ module ForestLiana
         end
 
         @records = @invoices.data.map do |d|
-          d.date = Time.at(d.date).to_datetime
+          d.date = Time.at(d.created).to_datetime
           d.period_start = Time.at(d.period_start).to_datetime
           d.period_end = Time.at(d.period_end).to_datetime
           d.subtotal /= 100.00


### PR DESCRIPTION
Hey, I've been having issues with the stripe out of the box integration.

I've been investigating the Stripe Docs and find out that the [stripe_invoice_serializer.rb](https://github.com/ForestAdmin/forest-rails/blob/a36791da9aa0321a20614a851cbf8c0f676402ba/app/serializers/forest_liana/stripe_invoice_serializer.rb) and the [stripe_invoices_getter.rb](https://github.com/ForestAdmin/forest-rails/blob/master/app/services/forest_liana/stripe_invoices_getter.rb#L35) both use parameters that aren't declared on the  [Stripe Invoice Object Documentation](https://stripe.com/docs/api/invoices/object).

I've made some tweaks to such files to use the parameters provided by Stripe, this changes fixed my issue but the dashboard is still showing the removed columns like `closed`, `forgiven`, etc.

## Pull Request checklist:

- [X] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Create automatic tests
- [ ] No automatic tests failures
- [X] Test manually the implemented changes
- [X] Review my own code (indentation, syntax, style, simplicity, readability)
- [X] Wonder if you can improve the existing code
