### PR TITLE
fix: use update instead of update_attributes to ensure rails 6.1 compatibility

### DIFF
--- a/app/services/forest_liana/resource_creator.rb
+++ b/app/services/forest_liana/resource_creator.rb
@@ -53,7 +53,7 @@ module ForestLiana
     end
 
     def has_strong_parameter
-      Rails::VERSION::MAJOR > 5 || @resource.instance_method(:update_attributes!).arity == 1
+      Rails::VERSION::MAJOR > 5 || @resource.instance_method(:update!).arity == 1
     end
   end
 end

--- a/app/services/forest_liana/resource_updater.rb
+++ b/app/services/forest_liana/resource_updater.rb
@@ -14,9 +14,9 @@ module ForestLiana
         @record = @resource.find(@params[:id])
 
         if has_strong_parameter
-          @record.update_attributes(resource_params)
+          @record.update(resource_params)
         else
-          @record.update_attributes(resource_params, without_protection: true)
+          @record.update(resource_params, without_protection: true)
         end
       rescue ActiveRecord::StatementInvalid => exception
         # NOTICE: SQL request cannot be executed properly
@@ -33,7 +33,7 @@ module ForestLiana
     end
 
     def has_strong_parameter
-      Rails::VERSION::MAJOR > 5 || @resource.instance_method(:update_attributes!).arity == 1
+      Rails::VERSION::MAJOR > 5 || @resource.instance_method(:update!).arity == 1
     end
   end
 end


### PR DESCRIPTION
(See also: https://github.com/ForestAdmin/forest-rails/pull/411 & https://github.com/ForestAdmin/forest-rails/pull/408)
https://blog.saeloun.com/2019/04/15/rails-6-deprecates-update-attributes.html
## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Create automatic tests
- [ ] No automatic tests failures
- [ ] Test manually the implemented changes
- [ ] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
