### PR TITLE
feat(auth): return a specific error during authorization if received  an error about 2FA (#d513um)

### DIFF
--- a/app/controllers/forest_liana/authentication_controller.rb
+++ b/app/controllers/forest_liana/authentication_controller.rb
@@ -86,8 +86,8 @@ module ForestLiana
         render json: response_body, status: 200
 
       rescue => error
-        render json: { errors: [{ status: 500, detail: error.message }] },
-          status: :internal_server_error, serializer: nil
+        render json: { errors: [{ status: error.error_code || 500, detail: error.message }] },
+          status: error.status || :internal_server_error, serializer: nil
       end
     end
 

--- a/app/services/forest_liana/authorization_getter.rb
+++ b/app/services/forest_liana/authorization_getter.rb
@@ -8,7 +8,7 @@ module ForestLiana
         response = ForestLiana::ForestApiRequester
           .get(route, query: {}, headers: headers)
 
-        if response[:code].to_i == 200
+        if response.code.to_i == 200
           body = JSON.parse(response.body, :symbolize_names => false)
           user = body['data']['attributes']
           user['id'] = body['data']['id']

--- a/app/services/forest_liana/authorization_getter.rb
+++ b/app/services/forest_liana/authorization_getter.rb
@@ -4,22 +4,38 @@ module ForestLiana
       begin
         route = "/liana/v2/renderings/#{rendering_id.to_s}/authorization"
         headers = { 'forest-token' => auth_data[:forest_token] }
-        query_parameters = {}
 
         response = ForestLiana::ForestApiRequester
-          .get(route, query: query_parameters, headers: headers)
+          .get(route, query: {}, headers: headers)
 
-        if response.code.to_i == 200
+        if response[:code].to_i == 200
           body = JSON.parse(response.body, :symbolize_names => false)
           user = body['data']['attributes']
           user['id'] = body['data']['id']
           user
         else
-            raise "Cannot authorize the user using this forest account. Forest API returned an #{Errors::HTTPErrorHelper.format(response)}"
+          raise generate_authentication_error response
         end
-      rescue
-        raise ForestLiana::Errors::HTTP401Error
       end
+    end
+
+    private
+    def self.generate_authentication_error(error)
+      case error[:message]
+      when ForestLiana::MESSAGES[:SERVER_TRANSACTION][:SECRET_AND_RENDERINGID_INCONSISTENT]
+        return ForestLiana::Errors::InconsistentSecretAndRenderingError.new()
+      when ForestLiana::MESSAGES[:SERVER_TRANSACTION][:SECRET_NOT_FOUND]
+        return ForestLiana::Errors::SecretNotFoundError.new()
+      else
+      end
+
+      serverError = error[:jse_cause][:response][:body][:errors][0] || nil
+
+      if !serverError.nil? && serverError[:name] == ForestLiana::MESSAGES[:SERVER_TRANSACTION][:names][:TWO_FACTOR_AUTHENTICATION_REQUIRED]
+        return ForestLiana::Errors::TwoFactorAuthenticationRequiredError.new()
+      end
+
+      return StandardError.new(error)
     end
   end
 end

--- a/config/initializers/error-messages.rb
+++ b/config/initializers/error-messages.rb
@@ -15,6 +15,9 @@ module ForestLiana
       INVALID_RENDERING_ID: "The parameter renderingId is not valid",
       REGISTRATION_FAILED: "The registration to the authentication API failed, response: ",
       OIDC_CONFIGURATION_RETRIEVAL_FAILED: "Failed to retrieve the provider's configuration.",
+      names: {
+        TWO_FACTOR_AUTHENTICATION_REQUIRED: 'TwoFactorAuthenticationRequiredForbiddenError',
+      }
     }
   }
 end

--- a/config/initializers/errors.rb
+++ b/config/initializers/errors.rb
@@ -16,7 +16,7 @@ module ForestLiana
     class ExpectedError < StandardError
       attr_reader :error_code, :status, :message, :name
 
-      def initialize(error_code, status, message, name)
+      def initialize(error_code, status, message, name = nil)
         @error_code = error_code
         @status = status
         @message = message

--- a/config/initializers/errors.rb
+++ b/config/initializers/errors.rb
@@ -14,12 +14,13 @@ module ForestLiana
     end
 
     class ExpectedError < StandardError
-      attr_reader :error_code, :status, :message
+      attr_reader :error_code, :status, :message, :name
 
-      def initialize(error_code, status, message)
+      def initialize(error_code, status, message, name)
         @error_code = error_code
         @status = status
         @message = message
+        @name = name
       end
 
       def display_error
@@ -42,6 +43,24 @@ module ForestLiana
     class HTTP422Error < ExpectedError
       def initialize(message = "Unprocessable Entity")
         super(422, :unprocessable_entity, message)
+      end
+    end
+
+    class InconsistentSecretAndRenderingError < ExpectedError
+      def initialize(message=ForestLiana::MESSAGES[:SERVER_TRANSACTION][:SECRET_AND_RENDERINGID_INCONSISTENT])
+        super(500, :internal_server_error, message, 'InconsistentSecretAndRenderingError')
+      end
+    end
+
+    class SecretNotFoundError < ExpectedError
+      def initialize(message=ForestLiana::MESSAGES[:SERVER_TRANSACTION][:SECRET_NOT_FOUND])
+        super(500, :internal_server_error, message, 'SecretNotFoundError')
+      end
+    end
+
+    class TwoFactorAuthenticationRequiredError < ExpectedError
+      def initialize(message='Two factor authentication required')
+        super(403, :forbidden, message, 'TwoFactorAuthenticationRequiredError')
       end
     end
 


### PR DESCRIPTION
This modification is needed to identify why the authorization failed, and display the correct error message in the frontend.

In this case, instead of a 500 with an error message, we get a 403 and the error's name correctly encoded in the response, just as the server sends errors.