### PR TITLE
fix(authentication): authentication error when the agent uses a prefix path in its url (#fb79c7)

### DIFF
--- a/app/controllers/forest_liana/authentication_controller.rb
+++ b/app/controllers/forest_liana/authentication_controller.rb
@@ -17,7 +17,7 @@ module ForestLiana
     end
   
     def get_callback_url
-        URI.join(ForestLiana.application_url, "/forest/#{CALLBACK_AUTHENTICATION_ROUTE}").to_s
+      File.join(ForestLiana.application_url, "/forest/#{CALLBACK_AUTHENTICATION_ROUTE}").to_s
     rescue => error
       raise "application_url is not valid or not defined" if error.is_a?(ArgumentError)
     end
@@ -70,8 +70,8 @@ module ForestLiana
         render json: response_body, status: 200
 
       rescue => error
-        render json: { errors: [{ status: error.try(:error_code) || 500, detail: error.message }] },
-          status: error.status || :internal_server_error, serializer: nil
+        render json: { errors: [{ status: error.try(:error_code) || 500, detail: error.try(:message) }] },
+          status: error.try(:status) || :internal_server_error, serializer: nil
       end
     end
 


### PR DESCRIPTION
See [this blog post](https://www.honeybadger.io/blog/why-is-uri-join-so-counterintuitive/) for the why.
