### PR TITLE
Allow the logger to be configurable by the parent application

### DIFF
--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -3,21 +3,24 @@ module ForestLiana
   class Logger
     class << self
       def log
-        logger = ::Logger.new(STDOUT)
-        logger_colors = {
-          DEBUG: 34,
-          WARN: 33,
-          ERROR: 31,
-          INFO: 37
-        }
+        if ForestLiana.custom_logger != nil
+          logger = ForestLiana.custom_logger
+        else
+          logger = ::Logger.new(STDOUT)
+          logger_colors = {
+            DEBUG: 34,
+            WARN: 33,
+            ERROR: 31,
+            INFO: 37
+          }
 
-        logger.formatter = proc do |severity, datetime, progname, message|
-          displayed_message = "[#{datetime.to_s(:db)}] Forest 🌳🌳🌳  " \
-            "#{message}\n"
-          "\e[#{logger_colors[severity.to_sym]}m#{displayed_message}\033[0m"
+          logger.formatter = proc do |severity, datetime, progname, message|
+            displayed_message = "[#{datetime.to_s(:db)}] Forest 🌳🌳🌳  " \
+                  "#{message}\n"
+                "\e[#{logger_colors[severity.to_sym]}m#{displayed_message}\033[0m"
+            end
+          logger
         end
-
-        logger
       end
     end
   end

--- a/lib/forest_liana.rb
+++ b/lib/forest_liana.rb
@@ -27,6 +27,7 @@ module ForestLiana
   mattr_accessor :user_class_name
   mattr_accessor :names_overriden
   mattr_accessor :meta
+  mattr_accessor :custom_logger
   # TODO: Remove once lianas prior to 2.0.0 are not supported anymore.
   mattr_accessor :names_old_overriden
 
@@ -38,6 +39,7 @@ module ForestLiana
   self.user_class_name = nil
   self.names_overriden = {}
   self.meta = {}
+  self.custom_logger = nil
 
   @config_dir = 'lib/forest_liana/**/*.rb'
 

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -21,6 +21,11 @@ module Dummy
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     # config.active_record.raise_in_transactional_callbacks = true
+    logger = ActiveSupport::Logger.new($stdout)
+    logger.formatter = proc do |severity, datetime, progname, msg|
+      {:message => msg}.to_json
+    end
+    ForestLiana.custom_logger = logger
   end
 end
 

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -21,6 +21,9 @@ module Dummy
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     # config.active_record.raise_in_transactional_callbacks = true
+
+    # Substitute to the default forest_liana logger implementation
+    # It's tested in forest_liana_test.rb (test 'override the log formatter')
     logger = ActiveSupport::Logger.new($stdout)
     logger.formatter = proc do |severity, datetime, progname, msg|
       {:message => msg}.to_json

--- a/test/forest_liana_test.rb
+++ b/test/forest_liana_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class ForestLianaTest < ActiveSupport::TestCase
+  include RSpec::Matchers
+
   test "truth" do
     assert_kind_of Module, ForestLiana
   end
@@ -21,5 +23,10 @@ class ForestLianaTest < ActiveSupport::TestCase
     )
 
     ForestLiana.config_dir = 'lib/forest_liana/**/*.rb'
+  end
+
+  test 'override the log formatter' do
+    expect { FOREST_LOGGER.error "[error] override logger" }.to output({:message => "[error] override logger"}.to_json).to_stdout_from_any_process
+    expect { FOREST_LOGGER.info "[info] override logger" }.to output({:message => "[info] override logger"}.to_json).to_stdout_from_any_process
   end
 end

--- a/test/forest_liana_test.rb
+++ b/test/forest_liana_test.rb
@@ -25,6 +25,8 @@ class ForestLianaTest < ActiveSupport::TestCase
     ForestLiana.config_dir = 'lib/forest_liana/**/*.rb'
   end
 
+  # Default logger is overrided by application bootstrap
+  # Test catches the output to $stdout with the help of rails-expectations
   test 'override the log formatter' do
     expect { FOREST_LOGGER.error "[error] override logger" }.to output({:message => "[error] override logger"}.to_json).to_stdout_from_any_process
     expect { FOREST_LOGGER.info "[info] override logger" }.to output({:message => "[info] override logger"}.to_json).to_stdout_from_any_process

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path("../../test/dummy/config/environment.rb",  __FILE__)
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../test/dummy/db/migrate", __FILE__)]
 ActiveRecord::Migrator.migrations_paths << File.expand_path('../../db/migrate', __FILE__)
 require "rails/test_help"
+require 'rspec/expectations'
 
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.


### PR DESCRIPTION
## Pull Request info

This pull request aims to allow parent application implementing ForestLiana to pass a custom logger. That way, forest-rails can stream all level of logs to an application controlled object that implements ::Logger

It was tested inside rspec, and with an custom application to produce JSON formatted logs instead of full-text 


## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Create automatic tests
- [x] No automatic tests failures
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
