### PR TITLE
fix(schema): generate the schema properly on server start while using the classic Autoloader using Rails 5

### DIFF
--- a/lib/forest_liana/engine.rb
+++ b/lib/forest_liana/engine.rb
@@ -66,7 +66,7 @@ module ForestLiana
         ActiveStorage::Attachment
       end
 
-      if Rails.autoloaders.zeitwerk_enabled?
+      if Rails::VERSION::MAJOR > 5 && Rails.autoloaders.zeitwerk_enabled?
         Zeitwerk::Loader.eager_load_all
       else
         app.eager_load!

--- a/lib/forest_liana/engine.rb
+++ b/lib/forest_liana/engine.rb
@@ -66,7 +66,7 @@ module ForestLiana
         ActiveStorage::Attachment
       end
 
-      if Rails::VERSION::MAJOR > 5 && defined?(Zeitwerk::Loader)
+      if Rails.autoloaders.zeitwerk_enabled?
         Zeitwerk::Loader.eager_load_all
       else
         app.eager_load!


### PR DESCRIPTION
Fixes issues in generating `.forestadmin-schema.json` ending up in an empty set of collections for Rails 6 projects using the Classic Autoloader.

The issue has been raised [here](https://community.forestadmin.com/t/forest-liana-upgrade-empty-collections/2502?u=alexis_philippart_de)
