### PR TITLE
fix(dependency): now using forestadmin-jsonapi-serializers instead of the jsonapi-serializers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
 end
 
 gem 'rails', '6.0.3.6'
-gem 'jsonapi-serializers', '1.0.1'
+gem 'forestadmin-jsonapi-serializers'
 gem 'rack-cors'
 gem 'arel-helpers', '2.11.0'
 gem 'groupdate', '5.2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,12 +4,12 @@ PATH
     forest_liana (6.4.0)
       arel-helpers
       bcrypt
+      forestadmin-jsonapi-serializers (>= 0.14.0)
       groupdate (>= 5.0.0)
       httparty
       ipaddress
       json
       json-jwt
-      jsonapi-serializers (>= 0.14.0)
       jwt
       openid_connect
       rack-cors
@@ -87,6 +87,8 @@ GEM
     diff-lcs (1.4.4)
     docile (1.3.5)
     erubi (1.10.0)
+    forestadmin-jsonapi-serializers (2.0.0.pre.beta.2)
+      activesupport
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     groupdate (5.2.2)
@@ -103,8 +105,6 @@ GEM
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
-    jsonapi-serializers (1.0.1)
-      activesupport
     jwt (2.2.3)
     loofah (2.9.1)
       crass (~> 1.0.2)
@@ -235,12 +235,12 @@ DEPENDENCIES
   bcrypt
   byebug
   forest_liana!
+  forestadmin-jsonapi-serializers
   groupdate (= 5.2.2)
   httparty (= 0.18.1)
   ipaddress (= 0.8.3)
   json
   json-jwt (= 1.12.0)
-  jsonapi-serializers (= 1.0.1)
   jwt
   openid_connect (= 1.2.0)
   rack-cors

--- a/app/controllers/forest_liana/application_controller.rb
+++ b/app/controllers/forest_liana/application_controller.rb
@@ -34,14 +34,14 @@ module ForestLiana
 
     def serialize_model(record, options = {})
       options[:is_collection] = false
-      json = JSONAPI::Serializer.serialize(record, options)
+      json = ForestAdmin::JSONAPI::Serializer.serialize(record, options)
 
       force_utf8_encoding(json)
     end
 
     def serialize_models(records, options = {}, fields_searched = [])
       options[:is_collection] = true
-      json = JSONAPI::Serializer.serialize(records, options)
+      json = ForestAdmin::JSONAPI::Serializer.serialize(records, options)
 
       if options[:params] && options[:params][:search]
         # NOTICE: Add the Smart Fields with a 'String' type.

--- a/app/controllers/forest_liana/associations_controller.rb
+++ b/app/controllers/forest_liana/associations_controller.rb
@@ -41,7 +41,7 @@ module ForestLiana
         updater.perform
 
         if updater.errors
-          render serializer: nil, json: JSONAPI::Serializer.serialize_errors(
+          render serializer: nil, json: ForestAdmin::JSONAPI::Serializer.serialize_errors(
             updater.errors), status: 422
         else
           head :no_content

--- a/app/controllers/forest_liana/base_controller.rb
+++ b/app/controllers/forest_liana/base_controller.rb
@@ -24,7 +24,7 @@ module ForestLiana
           end
         end
       rescue ForestLiana::Errors::ExpectedError => exception
-        error_data = JSONAPI::Serializer.serialize_errors([{
+        error_data = ForestAdmin::JSONAPI::Serializer.serialize_errors([{
           status: exception.error_code,
           detail: exception.message
         }])

--- a/app/controllers/forest_liana/resources_controller.rb
+++ b/app/controllers/forest_liana/resources_controller.rb
@@ -41,7 +41,7 @@ module ForestLiana
           status: :unprocessable_entity, serializer: nil
       rescue ForestLiana::Errors::ExpectedError => error
         error.display_error
-        error_data = JSONAPI::Serializer.serialize_errors([{
+        error_data = ForestAdmin::JSONAPI::Serializer.serialize_errors([{
           status: error.error_code,
           detail: error.message
         }])
@@ -73,7 +73,7 @@ module ForestLiana
           status: :unprocessable_entity, serializer: nil
       rescue ForestLiana::Errors::ExpectedError => error
         error.display_error
-        error_data = JSONAPI::Serializer.serialize_errors([{
+        error_data = ForestAdmin::JSONAPI::Serializer.serialize_errors([{
           status: error.error_code,
           detail: error.message
         }])
@@ -108,12 +108,12 @@ module ForestLiana
         creator.perform
 
         if creator.errors
-          render serializer: nil, json: JSONAPI::Serializer.serialize_errors(
+          render serializer: nil, json: ForestAdmin::JSONAPI::Serializer.serialize_errors(
             creator.errors), status: 400
         elsif creator.record.valid?
           render serializer: nil, json: render_record_jsonapi(creator.record)
         else
-          render serializer: nil, json: JSONAPI::Serializer.serialize_errors(
+          render serializer: nil, json: ForestAdmin::JSONAPI::Serializer.serialize_errors(
             creator.record.errors), status: 400
         end
       rescue => error
@@ -131,12 +131,12 @@ module ForestLiana
         updater.perform
 
         if updater.errors
-          render serializer: nil, json: JSONAPI::Serializer.serialize_errors(
+          render serializer: nil, json: ForestAdmin::JSONAPI::Serializer.serialize_errors(
             updater.errors), status: 400
         elsif updater.record.valid?
           render serializer: nil, json: render_record_jsonapi(updater.record)
         else
-          render serializer: nil, json: JSONAPI::Serializer.serialize_errors(
+          render serializer: nil, json: ForestAdmin::JSONAPI::Serializer.serialize_errors(
             updater.record.errors), status: 400
         end
       rescue => error

--- a/app/serializers/forest_liana/intercom_attribute_serializer.rb
+++ b/app/serializers/forest_liana/intercom_attribute_serializer.rb
@@ -1,6 +1,6 @@
 module ForestLiana
   class IntercomAttributeSerializer
-    include JSONAPI::Serializer
+    include ForestAdmin::JSONAPI::Serializer
 
     attribute :session_count
     attribute :last_seen_ip

--- a/app/serializers/forest_liana/intercom_conversation_serializer.rb
+++ b/app/serializers/forest_liana/intercom_conversation_serializer.rb
@@ -1,6 +1,6 @@
 module ForestLiana
   class IntercomConversationSerializer
-    include JSONAPI::Serializer
+    include ForestAdmin::JSONAPI::Serializer
 
     attribute :created_at
     attribute :updated_at

--- a/app/serializers/forest_liana/mixpanel_event_serializer.rb
+++ b/app/serializers/forest_liana/mixpanel_event_serializer.rb
@@ -1,6 +1,6 @@
 module ForestLiana
   class MixpanelEventSerializer
-    include JSONAPI::Serializer
+    include ForestAdmin::JSONAPI::Serializer
 
     attribute :id
     attribute :event

--- a/app/serializers/forest_liana/serializer_factory.rb
+++ b/app/serializers/forest_liana/serializer_factory.rb
@@ -53,7 +53,7 @@ module ForestLiana
 
     def serializer_for(active_record_class)
       serializer = Class.new {
-        include JSONAPI::Serializer
+        include ForestAdmin::JSONAPI::Serializer
 
         def self_link
           "/forest#{super.underscore}"

--- a/app/serializers/forest_liana/stat_serializer.rb
+++ b/app/serializers/forest_liana/stat_serializer.rb
@@ -1,6 +1,6 @@
 module ForestLiana
   class StatSerializer
-    include JSONAPI::Serializer
+    include ForestAdmin::JSONAPI::Serializer
 
     attribute :value
 

--- a/app/serializers/forest_liana/stripe_bank_account_serializer.rb
+++ b/app/serializers/forest_liana/stripe_bank_account_serializer.rb
@@ -1,6 +1,6 @@
 module ForestLiana
   class StripeBankAccountSerializer
-    include JSONAPI::Serializer
+    include ForestAdmin::JSONAPI::Serializer
 
     attribute :account_holder_name
     attribute :account_holder_type

--- a/app/serializers/forest_liana/stripe_card_serializer.rb
+++ b/app/serializers/forest_liana/stripe_card_serializer.rb
@@ -1,6 +1,6 @@
 module ForestLiana
   class StripeCardSerializer
-    include JSONAPI::Serializer
+    include ForestAdmin::JSONAPI::Serializer
 
     attribute :last4
     attribute :brand

--- a/app/serializers/forest_liana/stripe_invoice_serializer.rb
+++ b/app/serializers/forest_liana/stripe_invoice_serializer.rb
@@ -1,6 +1,6 @@
 module ForestLiana
   class StripeInvoiceSerializer
-    include JSONAPI::Serializer
+    include ForestAdmin::JSONAPI::Serializer
 
     attribute :amount_due
     attribute :amount_paid

--- a/app/serializers/forest_liana/stripe_payment_serializer.rb
+++ b/app/serializers/forest_liana/stripe_payment_serializer.rb
@@ -1,6 +1,6 @@
 module ForestLiana
   class StripePaymentSerializer
-    include JSONAPI::Serializer
+    include ForestAdmin::JSONAPI::Serializer
 
     attribute :description
     attribute :refunded

--- a/app/serializers/forest_liana/stripe_subscription_serializer.rb
+++ b/app/serializers/forest_liana/stripe_subscription_serializer.rb
@@ -1,6 +1,6 @@
 module ForestLiana
   class StripeSubscriptionSerializer
-    include JSONAPI::Serializer
+    include ForestAdmin::JSONAPI::Serializer
 
     attribute :cancel_at_period_end
     attribute :canceled_at

--- a/forest_liana.gemspec
+++ b/forest_liana.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*", "spec/**/*"]
 
   s.add_runtime_dependency "rails", ">= 4.0"
-  s.add_runtime_dependency "jsonapi-serializers", ">= 0.14.0"
+  s.add_runtime_dependency "forestadmin-jsonapi-serializers", ">= 0.14.0"
   s.add_runtime_dependency "jwt"
   s.add_runtime_dependency "rack-cors"
   s.add_runtime_dependency "arel-helpers"

--- a/lib/forest_liana/bootstrapper.rb
+++ b/lib/forest_liana/bootstrapper.rb
@@ -139,7 +139,7 @@ module ForestLiana
 
       # Monkey patch the find_serializer_class_name method to specify the
       # good serializer to use.
-      ::JSONAPI::Serializer.class_eval do
+      ::ForestAdmin::JSONAPI::Serializer.class_eval do
         def self.find_serializer_class_name(record, options)
           if record.respond_to?(:jsonapi_serializer_class_name)
             record.jsonapi_serializer_class_name.to_s


### PR DESCRIPTION
BREAKING CHANGE: Switch from jsonapi-serializers to forestadmin-jsonapi-serializers to serialize data to the JSONAPI format, mainly to avoid conflict with the jsonapi-serializer library

## Pull Request checklist:

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Create automatic tests
- [ ] No automatic tests failures
- [ ] Test manually the implemented changes
- [ ] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code
