### PR TITLE
fix: allow smart action endpoints to start with slashes

### DIFF
--- a/app/controllers/forest_liana/smart_actions_controller.rb
+++ b/app/controllers/forest_liana/smart_actions_controller.rb
@@ -57,11 +57,8 @@ module ForestLiana
 
     # smart action permissions are retrieved from the action's endpoint and http_method
     def get_smart_action_request_info
-      endpoint = request.fullpath
-      # Trim starting '/'
-      endpoint[0] = '' if endpoint[0] == '/'
       {
-        endpoint: endpoint,
+        endpoint: request.fullpath,
         http_method: request.request_method
       }
     end

--- a/app/services/forest_liana/utils/beta_schema_utils.rb
+++ b/app/services/forest_liana/utils/beta_schema_utils.rb
@@ -6,7 +6,7 @@ module ForestLiana
 
         return nil unless collection
 
-        collection.actions.find { |action| action.endpoint == endpoint && action.http_method == http_method }
+        collection.actions.find { |action| (action.endpoint == endpoint || "/#{action.endpoint}" == endpoint) && action.http_method == http_method }
       end
     end
   end


### PR DESCRIPTION
Be more flexible about endpoint beginning with slash.

The documentation provides default endpoint starting with slash
/ https://docs.forestadmin.com/documentation/v/v6/reference-guide/actions/create-and-manage-smart-actions#available-smart-action-options

But is was not working when endpoint starts with slash.
