### PR TITLE
fix: restrict the use of surrounding parentheses only to IN operator

### DIFF
--- a/spec/services/forest_liana/resource_updater_spec.rb
+++ b/spec/services/forest_liana/resource_updater_spec.rb
@@ -84,7 +84,7 @@ module ForestLiana
           subject.perform
 
           expect(subject.record).to be nil
-          expect(subject.errors[0][:detail]).to eq 'Couldn\'t find User with \'id\'=1 [WHERE (("users"."id" > (2)))]'
+          expect(subject.errors[0][:detail]).to eq 'Couldn\'t find User with \'id\'=1 [WHERE (("users"."id" > 2))]'
         end
       end
 


### PR DESCRIPTION
Although SQLite supports the surrounding parentheses for all operators, Postgresql does not.

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Create automatic tests
- [x] No automatic tests failures
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
