### PR TITLE
fix: restrict the use of surrounding parentheses only to IN operator

### DIFF
--- a/spec/services/forest_liana/resource_updater_spec.rb
+++ b/spec/services/forest_liana/resource_updater_spec.rb
@@ -84,7 +84,7 @@ module ForestLiana
           subject.perform
 
           expect(subject.record).to be nil
-          expect(subject.errors[0][:detail]).to eq 'Couldn\'t find User with \'id\'=1 [WHERE (("users"."id" > (2)))]'
+          expect(subject.errors[0][:detail]).to eq 'Couldn\'t find User with \'id\'=1 [WHERE (("users"."id" > 2))]'
         end
       end
 


### PR DESCRIPTION
Although SQLite support the surrounding parentheses for all operators, Postgresql does not.

Note: this branch comes from JoinRaylo:fix-filter-parser-brackets-bug
I'm moving it here so that i can change the commit message, and make it pass the linter step