### PR TITLE
feat: add uuid field type

### DIFF
--- a/app/services/forest_liana/schema_adapter.rb
+++ b/app/services/forest_liana/schema_adapter.rb
@@ -350,10 +350,12 @@ module ForestLiana
         type = 'Number'
       when :json, :jsonb, :hstore
         type = 'Json'
-      when :string, :text, :citext, :uuid
+      when :string, :text, :citext
         type = 'String'
       when :time
         type = 'Time'
+      when :uuid
+        type = 'Uuid'
       end
 
       is_array = (column.respond_to?(:array) && column.array == true)


### PR DESCRIPTION
Tickets
https://app.clickup.com/t/1crurfp
https://app.clickup.com/t/1cruua8

Front end PR
ForestAdmin/forestadmin#3675

UUID column type is supported by PostgreSQL and MySQL ActiveRecord adapters but not by SQLite adapter.

For PostgreSQL, add this in a migration :
`enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')`

For MySQL, add this in a migration :
`enable_extension 'uuid-ossp' unless extension_enabled?('uuid-ossp')`

I didn't add tests because the test suite runs on SQLite.