### PR TITLE
chore(workflow): bump setup-node and fix minimal node version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
       - beta
   pull_request:
 
+env:
+  NODE_VERSION: 12.13.0
+
 jobs:
   lint:
     name: Linting
@@ -18,7 +21,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -73,9 +78,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false # GITHUB_TOKEN must not be set for the semantic release
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12.13.0
+          node-version: ${{ env.NODE_VERSION }}
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'


### PR DESCRIPTION
### Description
> is blocking https://github.com/ForestAdmin/forest-rails/pull/528

Bump trusted external action from v1 to v2 (actions/setup-node)
Fix minimal node version to 12.x (the one already used in the deploy step)