### PR TITLE
Write to env the controller/action values for other middleware to use

### DIFF
--- a/app/controllers/forest_liana/router.rb
+++ b/app/controllers/forest_liana/router.rb
@@ -37,6 +37,8 @@ class ForestLiana::Router
           end
         end
 
+        params["action"] = action
+        params["controller"] = "#{env["SCRIPT_NAME"]}/#{collection_name}".delete_prefix("/")
         controller.action(action.to_sym).call(env)
       rescue NoMethodError => exception
         FOREST_REPORTER.report exception


### PR DESCRIPTION
When using certain middleware (in our case, [prometheus-exporter](https://github.com/discourse/prometheus_exporter/blob/main/lib/prometheus_exporter/middleware.rb#L54)), it is expected that the action and controller parameters are set by the router, as it's the case for the default Rails router.

This MR would ensure that these are filled in using reasonable values, without affecting anything else, and allow us to export metrics from Forest controllers not differently from what we do with our custom controllers.