### PR TITLE
Fix field sorting

### DIFF
--- a/lib/forest_liana/schema_file_updater.rb
+++ b/lib/forest_liana/schema_file_updater.rb
@@ -118,7 +118,7 @@ module ForestLiana
 
       # NOTICE: Sort keys
       @collections = @collections.map do |collection|
-        collection['fields'].sort do |field1, field2|
+        collection['fields'].sort! do |field1, field2|
           [field1['field'], field1['type'].inspect] <=> [field2['field'], field2['type'].inspect]
         end
 


### PR DESCRIPTION
## Definition of Done

### General

The line in the SchemaFileUpdater that was supposed to sort the fields of a collection in a schema was not doing anything. This fixes this, making the schema more reliable and easier to read.

### Security

No impact
