### PR TITLE
Fix: Forest JSON schema duplicate fields

### DIFF
--- a/lib/forest_liana/bootstrapper.rb
+++ b/lib/forest_liana/bootstrapper.rb
@@ -109,6 +109,7 @@ module ForestLiana
 
     def fetch_models
       ActiveRecord::Base.subclasses.each { |model| fetch_model(model) }
+      ForestLiana.models.uniq!
     end
 
     def fetch_model(model)


### PR DESCRIPTION
Given the following model hierarchy

```
module Screen
  class ApplicationRecord < ActiveRecord::Base
    self.abstract_class = true
  end
end

module Screen
  class Remediation < Screen::ApplicationRecord
    self.abstract_class = true
  end
end

module Screen
  class SctInRemediation < Screen::Remediation
    self.table_name = "remediations"
  end
end

module Screen
  class SctOutRemediation < Screen::Remediation
    self.table_name = "remediations"
  end
end
```

`ForestLiana.models` will include these child models twice, which will cause Forest
to generate a JSON schema with duplicated fields for the duplicated models.

```ruby
ForestLiana.models.group_by{ |e| e }.select { |k, v| v.size > 1 }.map(&:first)
=> [Screen::SctInRemediation (call 'Screen::SctInRemediation.connection' to establish a connection),
 Screen::SctOutRemediation (call 'Screen::SctOutRemediation.connection' to establish a connection),
 Screen::SddInRemediation (call 'Screen::SddInRemediation.connection' to establish a connection)]
```

```bash
❯ cat .forestadmin-schema.json | jq '.collections[24].name'
"Screen__SctInRemediation"

❯ cat .forestadmin-schema.json | jq '.collections[24].fields[] | .field ' | sort
comment"
"created_at"
"created_at"
"id"
"id"
"status"
"status"
"updated_at"
"updated_at"
```

