### PR TITLE
fix: Skip WHERE when computed search conditions are empty

### DIFF
--- a/app/services/forest_liana/search_query_builder.rb
+++ b/app/services/forest_liana/search_query_builder.rb
@@ -144,7 +144,7 @@ module ForestLiana
           conditions.join(' OR '),
           search_value_for_string: "%#{@search.downcase}%",
           search_value_for_uuid: @search.to_s
-        )
+        ) unless conditions.empty?
       end
 
       @records


### PR DESCRIPTION
Given an Active Record model with PK of type UUID:

```
+class CreateCardTransactions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :card_transactions, id: :uuid do |t|
+      t.timestamps
+    end
+  end
+end
```

And with a Forest collection with `search_fields` configured only for `id`
field:

```

module Forest
  class CardTransaction
    include ForestLiana::Collection

    collection :Card__Transaction

    search_fields %w[id]
  end
end
```

`SearchQueryBuilder` will generate an invalid SQL query with an empty
`WHERE` statement if search term doesn't meet `REGEX_UUID` format:

```sql
SELECT
    "transactions"."id" AS t0_r0,
    "transactions"."processed_at" AS
FROM "transactions"
WHERE  ORDER BY "transactions"."created_at"
DESC LIMIT $1 OFFSET $2  [["LIMIT", 10], ["OFFSET", 0]]

```

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made
