### PR TITLE
fix: prevent duplication of models from multiple ActiveRecord application classes

### DIFF
--- a/lib/forest_liana/bootstrapper.rb
+++ b/lib/forest_liana/bootstrapper.rb
@@ -114,14 +114,14 @@ module ForestLiana
     def fetch_model(model)
       begin
         if model.abstract_class?
-          model.descendants.each { |submodel| fetch_model(submodel) }
+          model.subclasses.each { |submodel| fetch_model(submodel) }
         else
           if is_sti_parent_model?(model)
-            model.descendants.each { |submodel_sti| fetch_model(submodel_sti) }
+            model.subclasses.each { |submodel_sti| fetch_model(submodel_sti) }
           end
 
           if analyze_model?(model)
-            ForestLiana.models << model
+            ForestLiana.models << model unless ForestLiana.models.include?(model)
           end
         end
       rescue => exception
@@ -136,7 +136,7 @@ module ForestLiana
     end
 
     def create_factories
-      ForestLiana.models.uniq.map do |model|
+      ForestLiana.models.map do |model|
         ForestLiana::SerializerFactory.new.serializer_for(model)
         ForestLiana::ControllerFactory.new.controller_for(model)
       end

--- a/spec/dummy/app/models/application_record.rb
+++ b/spec/dummy/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/spec/dummy/app/models/product.rb
+++ b/spec/dummy/app/models/product.rb
@@ -1,3 +1,3 @@
-class Product < ActiveRecord::Base
+class Product < ApplicationRecord
   validates :uri, presence: true, format: { with: URI::DEFAULT_PARSER.make_regexp }
 end

--- a/spec/dummy/app/models/reference.rb
+++ b/spec/dummy/app/models/reference.rb
@@ -1,2 +1,2 @@
-class Reference < ActiveRecord::Base
+class Reference < SubApplicationRecord
 end

--- a/spec/dummy/app/models/sub_application_record.rb
+++ b/spec/dummy/app/models/sub_application_record.rb
@@ -1,0 +1,3 @@
+class SubApplicationRecord < ApplicationRecord
+  self.abstract_class = true
+end


### PR DESCRIPTION
When the application defines multiple ActiveRecord application classes (for example [`ApplicationRecord`, as Rails documentation currently suggests](https://guides.rubyonrails.org/active_record_basics.html#creating-active-record-models)), the Forest schema contains duplicates of their subclass fields. It seems that the problem stems from a couple of innocent looking code lines:
 - The use of `subclasses` (which only gets direct children) in for the starting point:
 https://github.com/ForestAdmin/forest-rails/blob/d6d381d208335c54056a5dfea0db2281758041cb/lib/forest_liana/bootstrapper.rb#L111 and `descendants` (which gets direct and indirect children) in others:
 https://github.com/ForestAdmin/forest-rails/blob/d6d381d208335c54056a5dfea0db2281758041cb/lib/forest_liana/bootstrapper.rb#L117 and https://github.com/ForestAdmin/forest-rails/blob/d6d381d208335c54056a5dfea0db2281758041cb/lib/forest_liana/bootstrapper.rb#L120

 - The addition of models in the `ForestLiana.models` array when it might already contain them:
 https://github.com/ForestAdmin/forest-rails/blob/d6d381d208335c54056a5dfea0db2281758041cb/lib/forest_liana/bootstrapper.rb#L124
 It seems that some previous code tried to avoid this by using `uniq`:
 https://github.com/ForestAdmin/forest-rails/blob/d6d381d208335c54056a5dfea0db2281758041cb/lib/forest_liana/bootstrapper.rb#L139
 but I think we can prevent those issues (and probably more of the same kind downstream) by allowing only unique models in the array.

I have created two commits:
 - The first one adds and modifies some tests that expose the issue, but does not correct it. This will allow reviewers to see how it manifests.
 - The second one contains my suggested fix.

Please let me know if I should rebase them into one commit.

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made
