### PR TITLE
fix: Sort models by name after ActiveRecord::Base.descendants

### DIFF
--- a/lib/forest_liana/bootstrapper.rb
+++ b/lib/forest_liana/bootstrapper.rb
@@ -102,7 +102,7 @@ module ForestLiana
     end
 
     def fetch_models
-      ActiveRecord::Base.descendants.each { |model| fetch_model(model) }
+      ActiveRecord::Base.descendants.sort_by(&:name).each { |model| fetch_model(model) }
     end
 
     def fetch_model(model)


### PR DESCRIPTION
## Definition of Done

Models in `fetch_models` are sorted by alphabetical order as `ActiveRecord::Base.descendants` return value is not deterministic.
So classes order in `.forestadmin-schema.json` is the same for every developers.

(My team have undesirable changes in classes order in `.forestadmin-schema.json` despite using docker).

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made

# Notes

I didn't manage to run spec tests locally !.. This is what I did:
```
docker run -it --rm -v $(pwd):/src/app ruby bash
$ cd /src/app
$ bundle install
$ RAILS_ENV=test bundle exec rake --trace db:migrate test

Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.                                                               
** Invoke load_app (first_time)                                                                                                                                                                                                        
** Execute load_app                                                                                                                                                                                                                    
rake aborted!                                                                                                                                                                                                                          
NameError: uninitialized class variable @@schemes in URI                                                                                                                                                                               
Did you mean?  scheme_list                                                                                                                                                                                                             
/usr/local/bundle/gems/globalid-0.4.2/lib/global_id/uri/gid.rb:176:in `<module:URI>'
...
```
I have tested my changes by editing the gem source file in my project locally and it gives me the expected result.