### PR TITLE
Use stable sort for schema fields so we get same results across OS

### DIFF
--- a/app/services/forest_liana/schema_adapter.rb
+++ b/app/services/forest_liana/schema_adapter.rb
@@ -8,7 +8,7 @@ module ForestLiana
       add_columns
       add_associations
 
-      collection.fields.sort_by! { |k| k[:field].to_s }
+      collection.fields.sort_by!.with_index { |k, idx| [k[:field].to_s, idx] }
 
       # NOTICE: Add ActsAsTaggable fields
       if @model.try(:taggable?) && @model.respond_to?(:acts_as_taggable) &&


### PR DESCRIPTION
We get different results from the schema generation between
Linux and MacOS, the problem is that sort_by isn't stable:
https://stackoverflow.com/a/15442966
https://bugs.ruby-lang.org/issues/1089

The change was introduced recently [here](https://github.com/ForestAdmin/forest-rails/pull/561) and it already has tests (probably hard to test across OS) 