### PR TITLE
fix: schema version generation for all versions

### DIFF
--- a/lib/forest_liana/bootstrapper.rb
+++ b/lib/forest_liana/bootstrapper.rb
@@ -202,7 +202,7 @@ module ForestLiana
     def setup_forest_liana_meta
       ForestLiana.meta = {
         liana: 'forest-rails',
-        liana_version: ForestLiana::VERSION.sub!('.beta', '-beta'),
+        liana_version: ForestLiana::VERSION.sub('.beta', '-beta'),
         stack: {
            database_type: database_type,
            orm_version: Gem.loaded_specs["activerecord"].version.version,


### PR DESCRIPTION
## Background

The schema version generation resulted in a `null` value:

```ruby
ForestLiana::VERSION
# => "8.0.0"

ForestLiana::VERSION.sub!('.beta', '-beta')
# => nil
```

## Suggested fix

```ruby
ForestLiana::VERSION.sub('.beta', '-beta')
# => "8.0.0"
```

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made
