### PR TITLE
fix: permission checks using the collection name

### DIFF
--- a/spec/dummy/app/models/cars/motor.rb
+++ b/spec/dummy/app/models/cars/motor.rb
@@ -1,0 +1,4 @@
+module Cars
+  class Motor < ApplicationRecord
+  end
+end

--- a/spec/dummy/db/migrate/20230322104323_create_motors.rb
+++ b/spec/dummy/db/migrate/20230322104323_create_motors.rb
@@ -1,0 +1,8 @@
+class CreateMotors < ActiveRecord::Migration[6.0]
+  def change
+    create_table :motors do |t|
+      t.string :description
+      t.string :voltage
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_27_114930) do
+ActiveRecord::Schema.define(version: 2023_03_22_104323) do
 
   create_table "isle", force: :cascade do |t|
     t.string "name"
@@ -29,6 +29,11 @@ ActiveRecord::Schema.define(version: 2022_07_27_114930) do
 
   create_table "manufacturers", force: :cascade do |t|
     t.string "name"
+  end
+
+  create_table "motors", force: :cascade do |t|
+    t.string "description"
+    t.string "voltage"
   end
 
   create_table "owners", force: :cascade do |t|

--- a/spec/dummy/lib/forest_liana/collections/cars/motor.rb
+++ b/spec/dummy/lib/forest_liana/collections/cars/motor.rb
@@ -1,0 +1,11 @@
+module Forest
+  module Cars
+    class Motor
+      include ForestLiana::Collection
+
+      collection :Cars__Motor
+
+      action 'my_action'
+    end
+  end
+end


### PR DESCRIPTION
## Expected outcome


When the app has a model which is defined under a namespace (e.g. `Cars::Motor`)
And the user has permissions to access the Forest collection for that model
And the user is trying to access the data for that Forest collection
Then Forest should render the requested data

## Actual outcome

The Forest agent (`forest_liana`) raises an error resulting into a 500 page in the Forest UI


## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made
