### PR TITLE
fix(hooks): use exact namespace to prevent controller conflict

### DIFF
--- a/app/controllers/forest_liana/actions_controller.rb
+++ b/app/controllers/forest_liana/actions_controller.rb
@@ -1,5 +1,5 @@
 module ForestLiana
-  class ActionsController < ApplicationController
+  class ActionsController < ForestLiana::ApplicationController
 
     def get_smart_action_hook_request
       if params[:data] && params[:data][:attributes] && params[:data][:attributes][:collection_name]


### PR DESCRIPTION
### General

- [ Updating the syntax ] The base class will conflict with the class used by the application using this gem engine. Hence scoping the class with the module.

### Security

- NA
