### PR TITLE
fix: remove warning  forest_application_url

### DIFF
--- a/lib/forest_liana/bootstrapper.rb
+++ b/lib/forest_liana/bootstrapper.rb
@@ -28,11 +28,6 @@ module ForestLiana
           "ForestLiana.forest_client_id is deprecated. It's not needed anymore."
       end
 
-      if Rails.application.secrets.forest_application_url
-        FOREST_LOGGER.warn "DEPRECATION WARNING: The use of " \
-          "The secret forest_application_url is deprecated. It's not needed anymore."
-      end
-
       unless Rails.application.config.action_controller.perform_caching || Rails.env.test?
         FOREST_LOGGER.error "You need to enable caching on your environment to use Forest Admin.\n" \
           "For a development environment, run: `rails dev:cache`"


### PR DESCRIPTION
## Definition of Done

This PR removes an old warning concerning the use of the parameter : "forest_application_url" and avoids the use of "Rails.application.secrets" now deprecated on Rails >= 7.1


### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

