### PR TITLE
fix: include through associations referenced in filters in ResourcesGetter

### DIFF
--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -347,7 +347,30 @@ module ForestLiana
         end
       end
 
+      associations_from_filters.each do |association|
+        select << "#{@resource.table_name}.#{association.foreign_key}"
+      end
+
       select.uniq
+    end
+
+    def associations_from_filters
+      return [] unless filters_fields
+
+      filters_fields
+        .select { |field| field.include?(':') }
+        .map { |field| field.split(':').first }
+        .map { |field| get_one_association(field) }
+        .compact
+    end
+
+    def filters_fields
+      return unless @params[:filters]
+
+      parsed_filters = JSON.parse(@params[:filters])
+      # Different structure when multiple filters are applied
+      parsed_filters = parsed_filters['conditions'] if parsed_filters['conditions']
+      Array.wrap(parsed_filters).map { |filter| filter['field'] }.compact.uniq
     end
 
     def get_one_association(name)

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -177,6 +177,104 @@ describe 'Requesting Tree resources', :type => :request  do
         })
       end
     end
+
+    describe 'with a single filter on a through association that is not a displayed column when also including an unrelated association' do
+      params = {
+        fields: { 'Tree' => 'id,name,owner' },
+        filters: JSON.generate({
+          field: 'location:coordinates',
+          operator: 'equal',
+          value: '1,2'
+        }),
+        page: { 'number' => '1', 'size' => '10' },
+        searchExtended: '0',
+        sort: '-id',
+        timezone: 'Europe/Paris'
+      }
+
+      it 'should respond 200' do
+        get '/forest/Tree', params: params, headers: headers
+        expect(response.status).to eq(200)
+      end
+
+      it 'should respond with the tree data' do
+        get '/forest/Tree', params: params, headers: headers
+        expect(JSON.parse(response.body)).to match({
+          "data" => [{
+            "type" => "Tree",
+            "id" => "1",
+            "attributes" => {
+              "id" => 1,
+              "name" => "Lemon Tree"
+            },
+            "links" => {
+              "self" => "/forest/tree/1"
+            },
+            "relationships" => {
+              "owner" => {
+                "data" => { "id" => "1", "type" => "User" },
+                "links" => { "related" => {} }
+              }
+            }
+          }],
+          "included" => be_a(Array)
+        })
+      end
+    end
+
+    describe 'with multiple filters on a through association that is not a displayed column when also including an unrelated association' do
+      params = {
+        fields: { 'Tree' => 'id,name,owner' },
+        filters: JSON.generate({
+          aggregator: "or",
+          conditions: [
+            {
+              field: 'location:coordinates',
+              operator: 'equal',
+              value: '1,2'
+            },
+            {
+              field: 'location:coordinates',
+              operator: 'equal',
+              value: '2,3'
+            }
+          ]
+        }),
+        page: { 'number' => '1', 'size' => '10' },
+        searchExtended: '0',
+        sort: '-id',
+        timezone: 'Europe/Paris'
+      }
+
+      it 'should respond 200' do
+        get '/forest/Tree', params: params, headers: headers
+        expect(response.status).to eq(200)
+      end
+
+      it 'should respond with the tree data' do
+        get '/forest/Tree', params: params, headers: headers
+        expect(JSON.parse(response.body)).to match({
+          "data" => [{
+            "type" => "Tree",
+            "id" => "1",
+            "attributes" => {
+              "id" => 1,
+              "name" => "Lemon Tree"
+            },
+            "links" => {
+              "self" => "/forest/tree/1"
+            },
+            "relationships" => {
+              "owner" => {
+                "data" => { "id" => "1", "type" => "User" },
+                "links" => { "related" => {} }
+              }
+            }
+          }],
+          "included" => be_a(Array)
+        })
+      end
+    end
   end
 end
 

--- a/spec/services/forest_liana/resources_getter_spec.rb
+++ b/spec/services/forest_liana/resources_getter_spec.rb
@@ -306,6 +306,58 @@ module ForestLiana
       end
     end
 
+    describe 'when filtering on a field of a through association without including the field in the fields param and when also including an unrelated association' do
+      let(:resource) { Tree }
+      let(:fields) { { 'Tree' => 'id,name,owner' } }
+      let(:filters) { {
+        field: 'location:coordinates',
+        operator: 'equal',
+        value: '12345'
+      }.to_json }
+
+      it 'should get only the expected records' do
+        getter.perform
+        records = getter.records
+        count = getter.count
+
+        expect(records.count).to eq 2
+        expect(count).to eq 2
+        expect(records.map(&:id)).to eq [1, 2]
+        expect(records.map(&:name)).to eq ['Lemon Tree', 'Ginger Tree']
+      end
+    end
+
+    describe 'when filtering with multiple conditions on a field of a through association without including the field in the fields param and when also including an unrelated association' do
+      let(:resource) { Tree }
+      let(:fields) { { 'Tree' => 'id,name,owner' } }
+      let(:filters) { {
+        aggregator: "or",
+        conditions: [
+          {
+            field: 'location:coordinates',
+            operator: 'equal',
+            value: '12345'
+          },
+          {
+            field: 'location:coordinates',
+            operator: 'equal',
+            value: '54321'
+          }
+        ]
+      }.to_json }
+
+      it 'should get only the expected records' do
+        getter.perform
+        records = getter.records
+        count = getter.count
+
+        expect(records.count).to eq 3
+        expect(count).to eq 3
+        expect(records.map(&:id)).to eq [1, 2, 3]
+        expect(records.map(&:name)).to eq ['Lemon Tree', 'Ginger Tree', 'Apple Tree']
+      end
+    end
+
     describe 'when filtering on an ambiguous field' do
       let(:resource) { Tree }
       let(:pageSize) { 5 }


### PR DESCRIPTION
Hi 👋 

## Background
This PR is a follow up to my previous PR: https://github.com/ForestAdmin/forest-rails/pull/732
forest_liana 9.12.0 introduced a [db query optimisation](https://github.com/ForestAdmin/forest-rails/pull/729/files) which includes specifying fields which are to be fetched from the database.
I've found another situation where this causes an issue. Specifically, when there is a filter or multiple filters applied on the forest admin frontend on a through association which is not a displayed column.
I hope the specs I included explain the exact situation. You can reproduce the error if you comment out line 351 of `app/services/forest_liana/resources_getter.rb` (`select << "#{@resource.table_name}.#{association.foreign_key}"`) and run the new specs.

I'd appreciate your opinions on the approach taken and would be happy to help validate any alternative ones.

--

We've also experienced a few similar issues related to polymorphic associations which this PR does not fix.
I've had a hard time investigating those. However, I've found out that uncommenting [this particular line](https://github.com/ForestAdmin/forest-rails/blob/main/lib/forest_liana/active_record_override.rb#L36) in `lib/forest_liana/active_record_override.rb` seems to fix most of them.
Could you consider uncommenting this line in the next release? The issues I've mentioned block us from updating the gem at the moment.

## Affected Versions
Forest agent (forest_liana) >= 9.12.0

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made