### PR TITLE
feat: add feature flag to control usage of query optimizations

### DIFF
--- a/lib/forest_liana.rb
+++ b/lib/forest_liana.rb
@@ -29,6 +29,7 @@ module ForestLiana
   mattr_accessor :meta
   mattr_accessor :logger
   mattr_accessor :reporter
+  mattr_accessor :optimize_query_select_fields
   # TODO: Remove once lianas prior to 2.0.0 are not supported anymore.
   mattr_accessor :names_old_overriden
 
@@ -42,6 +43,7 @@ module ForestLiana
   self.meta = {}
   self.logger = nil
   self.reporter = nil
+  self.optimize_query_select_fields = true
 
   @config_dir = 'lib/forest_liana/**/*.rb'
 


### PR DESCRIPTION
## Context

I've encountered several issues with the query optimizations:
- the SQL produced for retrieving records with `has_one` associations is invalid (it's currently trying to select the foreign key from the main record's table) resulting in errors when rendering the view or exporting the view to CSV
- the SQL produced when the record has composite foreign keys is invalid resulting in errors when rendering the view

I've attempted to fix some of these issues myself, but I ended up realizing that the gem code needs extensive refactoring (and added test coverage) and unfortunately I don't have the necessary time to spend on it. 

These query optimizations are **breaking changes**, and have prevented us from upgrading the gem since the version `9.11.3`, so my suggestion is to allows us to use the gem without the query optimizations (which we know it is at least functional).


## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made
