### PR TITLE
feat(agent): add workflow executor proxy routes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,9 +141,7 @@ GEM
     marcel (1.1.0)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
-    minitest (6.0.1)
-      prism (~> 1.5)
+    minitest (5.27.0)
     multi_xml (0.7.2)
       bigdecimal (~> 3.1)
     mutex_m (0.3.0)
@@ -159,9 +157,6 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.10)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
     openid_connect (1.4.2)
@@ -176,7 +171,6 @@ GEM
       validate_url
       webfinger (~> 1.2)
     ostruct (0.6.3)
-    prism (1.7.0)
     psych (5.3.1)
       date
       stringio
@@ -257,8 +251,6 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.3)
-      mini_portile2 (~> 2.8.0)
     sqlite3 (1.7.3-arm64-darwin)
     stringio (3.2.0)
     swd (1.3.0)
@@ -290,6 +282,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-25
 
 DEPENDENCIES
   bcrypt
@@ -304,6 +297,7 @@ DEPENDENCIES
   json
   json-jwt (>= 1.16)
   jwt
+  minitest (~> 5.25)
   openid_connect (= 1.4.2)
   ostruct
   rack-cors

--- a/app/controllers/forest_liana/workflow_executions_controller.rb
+++ b/app/controllers/forest_liana/workflow_executions_controller.rb
@@ -3,6 +3,7 @@ require 'httparty'
 module ForestLiana
   class WorkflowExecutionsController < ApplicationController
     FORWARDED_HEADERS = %w[Authorization Cookie].freeze
+    UPSTREAM_TIMEOUT_IN_SECONDS = 10
     UPSTREAM_ERRORS = [
       HTTParty::Error,
       SocketError,
@@ -36,7 +37,8 @@ module ForestLiana
         headers: forwarded_headers,
         query: forwarded_query,
         body: forwarded_body(method),
-        verify: Rails.env.production?
+        verify: Rails.env.production?,
+        timeout: UPSTREAM_TIMEOUT_IN_SECONDS
       )
 
       render json: response.parsed_response, status: response.code

--- a/app/controllers/forest_liana/workflow_executions_controller.rb
+++ b/app/controllers/forest_liana/workflow_executions_controller.rb
@@ -1,0 +1,69 @@
+require 'httparty'
+
+module ForestLiana
+  class WorkflowExecutionsController < ApplicationController
+    FORWARDED_HEADERS = %w[Authorization Cookie].freeze
+    UPSTREAM_ERRORS = [
+      HTTParty::Error,
+      SocketError,
+      Errno::ECONNREFUSED,
+      Net::OpenTimeout,
+      Net::ReadTimeout,
+      Timeout::Error
+    ].freeze
+
+    def show
+      forward_to_executor(method: :get, suffix: '')
+    end
+
+    def trigger
+      forward_to_executor(method: :post, suffix: '/trigger')
+    end
+
+    private
+
+    def forward_to_executor(method:, suffix:)
+      base = ForestLiana.workflow_executor_url
+      if base.blank?
+        head :not_found
+        return
+      end
+
+      url = "#{base.sub(%r{/+\z}, '')}/runs/#{params[:run_id]}#{suffix}"
+      response = HTTParty.send(
+        method,
+        url,
+        headers: forwarded_headers,
+        query: forwarded_query,
+        body: forwarded_body(method),
+        verify: Rails.env.production?
+      )
+
+      render json: response.parsed_response, status: response.code
+    rescue *UPSTREAM_ERRORS => e
+      Rails.logger.error("[ForestLiana] workflow executor proxy error: #{e.class}: #{e.message}")
+      render json: { error: 'workflow_executor_unreachable' }, status: :service_unavailable
+    end
+
+    def forwarded_headers
+      base = { 'Content-Type' => 'application/json' }
+      FORWARDED_HEADERS.each_with_object(base) do |name, acc|
+        value = request.headers[name]
+        acc[name] = value if value.present?
+      end
+    end
+
+    def forwarded_query
+      params
+        .except(:run_id, :controller, :action, :format)
+        .to_unsafe_h
+    end
+
+    def forwarded_body(method)
+      return nil if method == :get
+
+      raw = request.raw_post
+      raw.presence
+    end
+  end
+end

--- a/app/services/forest_liana/token.rb
+++ b/app/services/forest_liana/token.rb
@@ -9,7 +9,8 @@ module ForestLiana
     end
 
     def self.expiration_in_seconds
-      return Time.now.to_i + EXPIRATION_IN_SECONDS.to_i   # .to_i → Integer, conforme RFC 7519
+      # NOTICE: Cast to Integer so the JWT exp claim is an RFC 7519 NumericDate.
+      return Time.now.to_i + EXPIRATION_IN_SECONDS.to_i
     end
 
     def self.create_token(user, rendering_id)

--- a/app/services/forest_liana/token.rb
+++ b/app/services/forest_liana/token.rb
@@ -9,7 +9,7 @@ module ForestLiana
     end
 
     def self.expiration_in_seconds
-      return Time.now.to_i + EXPIRATION_IN_SECONDS
+      return Time.now.to_i + EXPIRATION_IN_SECONDS.to_i   # .to_i → Integer, conforme RFC 7519
     end
 
     def self.create_token(user, rendering_id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,12 @@ ForestLiana::Engine.routes.draw do
   # Scopes
   post '/scope-cache-invalidation' => 'scopes#invalidate_scope_cache'
 
+  # Workflow executor proxy (mounted only when ForestLiana.workflow_executor_url is set)
+  if ForestLiana.workflow_executor_url.present?
+    get  '_internal/workflow-executions/:run_id'         => 'workflow_executions#show'
+    post '_internal/workflow-executions/:run_id/trigger' => 'workflow_executions#trigger'
+  end
+
   # Stripe Integration
   get '(*collection)_stripe_payments' => 'stripe#payments'
   get ':collection/:id/stripe_payments' => 'stripe#payments'

--- a/lib/forest_liana.rb
+++ b/lib/forest_liana.rb
@@ -30,6 +30,7 @@ module ForestLiana
   mattr_accessor :logger
   mattr_accessor :reporter
   mattr_accessor :skip_schema_update
+  mattr_accessor :workflow_executor_url
   # TODO: Remove once lianas prior to 2.0.0 are not supported anymore.
   mattr_accessor :names_old_overriden
 

--- a/spec/dummy/config/initializers/forest_liana.rb
+++ b/spec/dummy/config/initializers/forest_liana.rb
@@ -1,3 +1,4 @@
 ForestLiana.env_secret = 'env_secret_test'
 ForestLiana.auth_secret = 'auth_secret_test'
 ForestLiana.application_url = 'http://localhost:3000'
+ForestLiana.workflow_executor_url = 'http://workflow-executor.test:4001'

--- a/spec/requests/workflow_executions_spec.rb
+++ b/spec/requests/workflow_executions_spec.rb
@@ -1,0 +1,153 @@
+require 'rails_helper'
+
+describe 'Workflow executor proxy', type: :request do
+  let(:run_id) { 'run_abc123' }
+  let(:executor_url) { 'http://workflow-executor.test:4001' }
+  let(:bearer_token) do
+    JWT.encode(
+      {
+        id: 38,
+        email: 'michael.kelso@that70.show',
+        first_name: 'Michael',
+        last_name: 'Kelso',
+        team: 'Operations',
+        rendering_id: 16,
+        exp: Time.now.to_i + 2.weeks.to_i,
+        permission_level: 'admin'
+      },
+      ForestLiana.auth_secret,
+      'HS256'
+    )
+  end
+  let(:auth_headers) do
+    {
+      'Accept' => 'application/json',
+      'Content-Type' => 'application/json',
+      'Authorization' => "Bearer #{bearer_token}",
+      'Cookie' => 'forest_session_token=session-xyz'
+    }
+  end
+  let(:executor_response) do
+    instance_double(
+      HTTParty::Response,
+      parsed_response: { 'id' => run_id, 'state' => 'pending' },
+      code: 200
+    )
+  end
+
+  before do
+    allow(ForestLiana::IpWhitelist).to receive(:retrieve) { true }
+    allow(ForestLiana::IpWhitelist).to receive(:is_ip_whitelist_retrieved) { true }
+    allow(ForestLiana::IpWhitelist).to receive(:is_ip_valid) { true }
+
+    allow(HTTParty).to receive(:get).and_return(executor_response)
+    allow(HTTParty).to receive(:post).and_return(executor_response)
+  end
+
+  describe 'GET /forest/_internal/workflow-executions/:run_id' do
+    it 'forwards GET to the executor /runs/:run_id endpoint' do
+      get "/forest/_internal/workflow-executions/#{run_id}", params: { foo: 'bar' }, headers: auth_headers
+
+      expect(HTTParty).to have_received(:get).with(
+        "#{executor_url}/runs/#{run_id}",
+        hash_including(
+          headers: hash_including(
+            'Authorization' => "Bearer #{bearer_token}",
+            'Cookie' => 'forest_session_token=session-xyz'
+          ),
+          query: hash_including('foo' => 'bar')
+        )
+      )
+    end
+
+    it 'returns the executor status and body verbatim' do
+      get "/forest/_internal/workflow-executions/#{run_id}", headers: auth_headers
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)).to eq('id' => run_id, 'state' => 'pending')
+    end
+
+    it 'rejects unauthenticated requests with 401' do
+      get "/forest/_internal/workflow-executions/#{run_id}"
+
+      expect(response.status).to eq(401)
+      expect(HTTParty).not_to have_received(:get)
+    end
+  end
+
+  describe 'POST /forest/_internal/workflow-executions/:run_id/trigger' do
+    let(:trigger_body) { { step: 'approve', value: 42 } }
+
+    it 'forwards POST to the executor /runs/:run_id/trigger endpoint with the body' do
+      post(
+        "/forest/_internal/workflow-executions/#{run_id}/trigger",
+        params: trigger_body.to_json,
+        headers: auth_headers
+      )
+
+      expect(HTTParty).to have_received(:post).with(
+        "#{executor_url}/runs/#{run_id}/trigger",
+        hash_including(
+          headers: hash_including('Authorization' => "Bearer #{bearer_token}"),
+          body: trigger_body.to_json
+        )
+      )
+    end
+
+    it 'returns the executor response' do
+      post(
+        "/forest/_internal/workflow-executions/#{run_id}/trigger",
+        params: trigger_body.to_json,
+        headers: auth_headers
+      )
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)).to eq('id' => run_id, 'state' => 'pending')
+    end
+  end
+
+  describe 'when the executor returns an error status' do
+    let(:executor_response) do
+      instance_double(HTTParty::Response, parsed_response: { 'error' => 'invalid_step' }, code: 422)
+    end
+
+    it 'forwards the executor status and body to the client' do
+      get "/forest/_internal/workflow-executions/#{run_id}", headers: auth_headers
+
+      expect(response.status).to eq(422)
+      expect(JSON.parse(response.body)).to eq('error' => 'invalid_step')
+    end
+  end
+
+  describe 'when the executor is unreachable' do
+    before do
+      allow(HTTParty).to receive(:get).and_raise(Errno::ECONNREFUSED.new('boom'))
+    end
+
+    it 'returns 503 service_unavailable' do
+      get "/forest/_internal/workflow-executions/#{run_id}", headers: auth_headers
+
+      expect(response.status).to eq(503)
+      expect(JSON.parse(response.body)).to eq('error' => 'workflow_executor_unreachable')
+    end
+  end
+
+  describe 'when ForestLiana.workflow_executor_url is blank' do
+    around do |example|
+      original = ForestLiana.workflow_executor_url
+      ForestLiana.workflow_executor_url = nil
+      example.run
+    ensure
+      ForestLiana.workflow_executor_url = original
+    end
+
+    it 'returns 404 (controller-level guard for cases where routes were drawn but config was reset)' do
+      # Note: routes are mounted at boot based on workflow_executor_url being
+      # present. This test exercises the runtime guard inside the controller
+      # for scenarios where config is mutated after boot (e.g. tests).
+      get "/forest/_internal/workflow-executions/#{run_id}", headers: auth_headers
+
+      expect(response.status).to eq(404)
+    end
+  end
+end


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add workflow executor proxy routes to `WorkflowExecutionsController`
- Adds a new `ForestLiana::WorkflowExecutionsController` that proxies `GET /_internal/workflow-executions/:run_id` and `POST /_internal/workflow-executions/:run_id/trigger` to an external workflow executor service.
- Routes are conditionally mounted only when `ForestLiana.workflow_executor_url` is configured; returns 404 otherwise.
- Forwards `Authorization` and `Cookie` headers, query params, and raw POST body to the upstream service, returning its status and response verbatim.
- Adds a `workflow_executor_url` config accessor to [lib/forest_liana.rb](https://github.com/ForestAdmin/forest-rails/pull/769/files#diff-6be73c6e69bbf46e74935a6a6133bbce785f870e48f0bdef282a18055bc6bcb3).
- Risk: upstream connectivity failures return 503 after a 10-second timeout; SSL verification is skipped outside of production.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized c608d79.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->