### PR TITLE
fix: search array uuid columns using ANY() operator

### DIFF
--- a/app/services/forest_liana/search_query_builder.rb
+++ b/app/services/forest_liana/search_query_builder.rb
@@ -75,7 +75,11 @@ module ForestLiana
             end
           # NOTICE: Rails 3 do not have a defined_enums method
           elsif REGEX_UUID.match(@search) && column.type == :uuid
-            conditions << "#{column_name}  = :search_value_for_uuid"
+            if column.respond_to?(:array) && column.array
+              conditions << ":search_value_for_uuid = ANY(#{column_name})"
+            else
+              conditions << "#{column_name}  = :search_value_for_uuid"
+            end
           elsif @resource.respond_to?(:defined_enums) &&
             @resource.defined_enums.has_key?(column.name) &&
             !@resource.defined_enums[column.name][@search.downcase].nil?

--- a/spec/services/forest_liana/search_query_builder_spec.rb
+++ b/spec/services/forest_liana/search_query_builder_spec.rb
@@ -1,0 +1,48 @@
+module ForestLiana
+  describe SearchQueryBuilder do
+    let(:user) { { 'id' => '1', 'rendering_id' => 1 } }
+    let(:collection) { ForestLiana::Model::Collection.new(name: 'Tree', fields: []) }
+    let(:search_uuid) { '75fbcb43-f6f8-4cd1-861f-09a61fd1ddad' }
+    let(:params) { { search: search_uuid, searchExtended: '0' } }
+    let(:builder) { described_class.new(params, [], collection, user) }
+
+    before do
+      allow(ForestLiana::ScopeManager)
+        .to receive(:append_scope_for_user)
+        .and_return(nil)
+      allow(ForestLiana)
+        .to receive(:schema_for_resource)
+        .and_return(ForestLiana::Model::Collection.new(name: 'Tree', fields: []))
+    end
+
+    describe '#perform' do
+      context 'when a column is an array uuid type' do
+        let(:array_uuid_column) do
+          double('Column', name: 'attachment_ids', type: :uuid, array: true).tap do |col|
+            allow(col).to receive(:respond_to?).with(:array).and_return(true)
+          end
+        end
+
+        let(:normal_uuid_column) do
+          double('Column', name: 'external_id', type: :uuid, array: false).tap do |col|
+            allow(col).to receive(:respond_to?).with(:array).and_return(true)
+          end
+        end
+
+        before do
+          allow(Tree).to receive(:columns).and_return([array_uuid_column, normal_uuid_column])
+        end
+
+        it 'searches the array column using ANY() syntax' do
+          result = builder.perform(Tree.all)
+          expect(result.to_sql).to match(/= ANY.*attachment_ids/i)
+        end
+
+        it 'searches the non-array uuid column using equality syntax' do
+          result = builder.perform(Tree.all)
+          expect(result.to_sql).to match(/"external_id"\s+=\s+'#{search_uuid}'/i)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

When performing a full-text search on a collection that contains `uuid[]` (array of UUID) columns, Forest Rails generates a plain `=` comparison:

```sql
"attachment_ids" = '018e7fc6-d8a6-7ceb-b80e-d0972603e1b5'
```

PostgreSQL rejects this with:

```
PG::InvalidTextRepresentation: ERROR: malformed array literal: "018e7fc6-..."
DETAIL: Array value must start with "{" or dimension information.
```

This causes a 500 error and locks agents from performing searches on any collection that has array-typed UUID fields.

## Solution

When the search term is a valid UUID and the target column is of type `:uuid`, check whether it is also an array column. If so, use the PostgreSQL `ANY()` operator instead of `=`:

```sql
'018e7fc6-d8a6-7ceb-b80e-d0972603e1b5' = ANY("attachment_ids")
```

This correctly checks whether the UUID appears anywhere in the array.

Non-array UUID columns and all other column types are unaffected. The `column.array` attribute is PostgreSQL-specific, so MySQL and SQLite are also unaffected.

## Changes

- `app/services/forest_liana/search_query_builder.rb`: branch on `column.array` when building the UUID search condition
- `spec/services/forest_liana/search_query_builder_spec.rb`: new spec covering both the `ANY()` path for array columns and the `=` path for scalar columns

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix UUID search on array columns using `ANY()` operator
> Equality checks on PostgreSQL `uuid[]` array columns always failed when searching by UUID. [search_query_builder.rb](https://github.com/ForestAdmin/forest-rails/pull/770/files#diff-fa135f02c0c5311220e1b811b2332b4c7e337954342efc5a94503d847d836841) now detects array-typed UUID columns and switches to a `:search_value_for_uuid = ANY(column_name)` condition, while non-array UUID columns retain the existing equality check.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ebabca5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->