### PR TITLE
fix: skip bootstrapper during rails-invoked rake tasks

### DIFF
--- a/lib/forest_liana/engine.rb
+++ b/lib/forest_liana/engine.rb
@@ -64,9 +64,7 @@ module ForestLiana
       #         models mid-migration (crashing on enums backed by a pending column).
       return true if File.basename($0) == 'rake'
 
-      defined?(Rake) &&
-        Rake.respond_to?(:application) &&
-        Rake.application.top_level_tasks.any? { |task| task != 'default' }
+      defined?(Rake) && Rake.application.top_level_tasks.any? { |task| task != 'default' }
     end
 
     def database_available?

--- a/lib/forest_liana/engine.rb
+++ b/lib/forest_liana/engine.rb
@@ -59,7 +59,14 @@ module ForestLiana
     end
 
     def rake?
-      File.basename($0) == 'rake'
+      # NOTICE: `rails db:migrate` runs through Rake but exposes $0 as `rails`,
+      #         so matching the binary name alone let the bootstrapper introspect
+      #         models mid-migration (crashing on enums backed by a pending column).
+      return true if File.basename($0) == 'rake'
+
+      defined?(Rake) &&
+        Rake.respond_to?(:application) &&
+        Rake.application.top_level_tasks.any? { |task| task != 'default' }
     end
 
     def database_available?

--- a/spec/lib/forest_liana/engine_spec.rb
+++ b/spec/lib/forest_liana/engine_spec.rb
@@ -1,0 +1,50 @@
+require 'rake'
+
+module ForestLiana
+  describe Engine do
+    subject(:engine) { ForestLiana::Engine.instance }
+
+    describe '#rake?' do
+      around do |example|
+        original_program_name = $0
+        example.run
+        $0 = original_program_name
+      end
+
+      context 'when invoked through the legacy `rake` binary' do
+        it 'returns true' do
+          $0 = '/usr/local/bin/rake'
+
+          expect(engine.rake?).to be(true)
+        end
+      end
+
+      context 'when invoked through `rails` while running a Rake task (e.g. rails db:migrate)' do
+        it 'returns true so the bootstrapper does not introspect models mid-task' do
+          $0 = '/usr/local/bin/rails'
+          allow(Rake.application).to receive(:top_level_tasks).and_return(['db:migrate'])
+
+          expect(engine.rake?).to be(true)
+        end
+      end
+
+      context 'when booting the application to serve (rails server / console)' do
+        it 'returns false so the bootstrapper runs and builds the apimap' do
+          $0 = '/usr/local/bin/rails'
+          allow(Rake.application).to receive(:top_level_tasks).and_return([])
+
+          expect(engine.rake?).to be(false)
+        end
+      end
+
+      context 'when only the default Rake task is present' do
+        it 'returns false' do
+          $0 = '/usr/local/bin/rails'
+          allow(Rake.application).to receive(:top_level_tasks).and_return(['default'])
+
+          expect(engine.rake?).to be(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Running `rails db:migrate` crashes with **`Undeclared attribute type for enum`** when a model declares an `enum` on a column added by the *pending* migration — but only when Forest Admin is configured.

Reported by a customer; reproduced on Rails 7.1 **and** 8.1.

## Root cause

The `rake?` guard in `engine.rb` only matched the legacy `rake` binary:

```ruby
File.basename($0) == 'rake'
```

`rails db:migrate` delegates to Rake under the hood but exposes `$0` as `rails`, so the guard returned `false`. The `Bootstrapper` therefore ran in `after_initialize` and introspected **all** models mid-migration (`Bootstrapper.new` → `create_factories` → `SerializerFactory#attributes`), forcing `load_schema!` while the code was legitimately ahead of the DB. ActiveRecord then raises on the enum whose backing column doesn't exist yet.

Note: `FOREST_DISABLE_AUTO_SCHEMA_APPLY` does **not** help here — it only guards the `synchronize` (network) call, not `Bootstrapper.new`.

## Fix

Detect any Rake task context via `Rake.application.top_level_tasks`, so the bootstrapper is skipped for `rails db:migrate` & co., while still running for real application boots (`server`/`console`/`runner`) where the in-memory apimap is required.

## Tests

- New `spec/lib/forest_liana/engine_spec.rb` covering: legacy `rake` binary, `rails` + running task, `rails` + no task (server/console), and `default`-only task.
- Validated end-to-end on a Rails 8.1 app: `rails db:migrate` with a pending enum column now passes, and the bootstrapper still runs on app boot (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ForestLiana::Engine.rake?` to detect Rails-invoked Rake tasks like `db:migrate`
> Previously, `rake?` only checked if the running binary was named `rake`, which missed cases like `rails db:migrate` where `$0` is `rails` but Rake is driving execution. The method now also returns `true` when `Rake` is defined, `Rake.application` is present, and `top_level_tasks` contains any task other than `default`. Tests in [engine_spec.rb](https://github.com/ForestAdmin/forest-rails/pull/771/files#diff-94dc3de1c1c8c5096e65430e89ba6f1b40e0874883c2f1e0e5d8e21dc3d28040) cover the legacy binary check, Rails-invoked tasks, and the `default`-only edge case.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #771 opened
>
> - Refactored `ForestLiana.Engine.rake?` method to directly access `Rake.application` without checking `respond_to?(:application)` [e56b16a]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d70a120.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->