### PR TITLE
fix(schema): emit is_primary_key flag on collection fields

### DIFF
--- a/app/models/forest_liana/model/collection.rb
+++ b/app/models/forest_liana/model/collection.rb
@@ -37,6 +37,7 @@ class ForestLiana::Model::Collection
       field[:enums] = nil unless field.key?(:enums)
       field[:integration] = nil unless field.key?(:integration)
       field[:is_filterable] = true unless field.key?(:is_filterable)
+      field[:is_primary_key] = false unless field.key?(:is_primary_key)
       field[:is_read_only] = false unless field.key?(:is_read_only)
       field[:is_required] = false unless field.key?(:is_required)
       field[:is_sortable] = true unless field.key?(:is_sortable)

--- a/app/services/forest_liana/apimap_sorter.rb
+++ b/app/services/forest_liana/apimap_sorter.rb
@@ -20,6 +20,7 @@ module ForestLiana
       'enums',
       'integration',
       'is_filterable',
+      'is_primary_key',
       'is_read_only',
       'is_required',
       'is_sortable',

--- a/app/services/forest_liana/schema_adapter.rb
+++ b/app/services/forest_liana/schema_adapter.rb
@@ -248,6 +248,7 @@ module ForestLiana
               relationship: get_relationship_type(association),
               reference: "#{association.name.to_s}.id",
               inverse_of: @model.name.demodulize.underscore,
+              is_primary_key: false,
               is_filterable: false,
               is_sortable: true,
               is_read_only: false,
@@ -278,6 +279,7 @@ module ForestLiana
               field[:field] = association.name
               field[:inverse_of] = inverse_of(association)
               field[:relationship] = get_relationship_type(association)
+              field[:is_primary_key] = false
 
               ForestLiana::SchemaUtils.disable_filter_and_sort_if_cross_db!(
                 field,
@@ -332,6 +334,7 @@ module ForestLiana
       schema = {
         field: column.name,
         type: column_type,
+        is_primary_key: primary_key?(column),
         is_filterable: true,
         is_sortable: true,
         is_read_only: false,
@@ -351,6 +354,16 @@ module ForestLiana
       add_validations(schema, column)
     end
 
+    def primary_key?(column)
+      pk = @model.primary_key
+      if pk.is_a?(Array)
+        # NOTICE: composite_primary_keys exposes an Array of column names.
+        pk.map(&:to_s).include?(column.name)
+      else
+        !pk.nil? && pk.to_s == column.name
+      end
+    end
+
     def get_schema_for_association(association)
       opts ={
         field: association.name.to_s,
@@ -358,6 +371,7 @@ module ForestLiana
         relationship: get_relationship_type(association),
         reference: "#{ForestLiana.name_for(association.klass)}.id",
         inverse_of: inverse_of(association),
+        is_primary_key: false,
         is_filterable: !is_many_association(association),
         is_sortable: true,
         is_read_only: false,

--- a/lib/forest_liana/collection.rb
+++ b/lib/forest_liana/collection.rb
@@ -68,6 +68,7 @@ module ForestLiana::Collection
       opts[:is_read_only] = true unless opts.has_key?(:is_read_only)
       opts[:is_read_only] = false if opts.has_key?(:set)
       opts[:is_required] = false unless opts.has_key?(:is_required)
+      opts[:is_primary_key] = false unless opts.has_key?(:is_primary_key)
       opts[:type] = "String" unless opts.has_key?(:type)
       opts[:default_value] = nil unless opts.has_key?(:default_value)
       opts[:integration] = nil unless opts.has_key?(:integration)

--- a/lib/forest_liana/schema_file_updater.rb
+++ b/lib/forest_liana/schema_file_updater.rb
@@ -26,6 +26,7 @@ module ForestLiana
       'enums',
       'integration',
       'is_filterable',
+      'is_primary_key',
       'is_read_only',
       'is_required',
       'is_sortable',
@@ -86,6 +87,7 @@ module ForestLiana
           field['enums'] = nil unless field.has_key?('enums')
           field['integration'] = nil unless field.has_key?('integration')
           field['is_filterable'] = false unless field.has_key?('is_filterable')
+          field['is_primary_key'] = false unless field.has_key?('is_primary_key')
           field['is_read_only'] = true unless field.has_key?('is_read_only')
           field['is_required'] = false unless field.has_key?('is_required')
           field['is_sortable'] = false unless field.has_key?('is_sortable')

--- a/spec/lib/forest_liana/collection_spec.rb
+++ b/spec/lib/forest_liana/collection_spec.rb
@@ -25,6 +25,7 @@ module ForestLiana
             validations: [],
             is_virtual: true,
             field: :address_type,
+            is_primary_key: false,
             is_filterable: false,
             is_sortable: false
           }

--- a/spec/services/forest_liana/schema_adapter_spec.rb
+++ b/spec/services/forest_liana/schema_adapter_spec.rb
@@ -15,6 +15,7 @@ module ForestLiana
               relationship: "BelongsTo",
               reference: "addressable.id",
               inverse_of: "address",
+              is_primary_key: false,
               is_filterable: false,
               is_sortable: true,
               is_read_only: false,

--- a/test/services/forest_liana/schema_adapter_test.rb
+++ b/test/services/forest_liana/schema_adapter_test.rb
@@ -36,6 +36,39 @@ module ForestLiana
       assert fields.size == 1
     end
 
+    test 'the standard primary key column is flagged is_primary_key: true' do
+      adapter = SchemaAdapter.new(IntegerField)
+      schema = adapter.send(:get_schema_for_column, IntegerField.columns_hash['id'])
+      assert_equal true, schema[:is_primary_key]
+    end
+
+    test 'a non primary key column is flagged is_primary_key: false' do
+      adapter = SchemaAdapter.new(IntegerField)
+      schema = adapter.send(:get_schema_for_column, IntegerField.columns_hash['field'])
+      assert_equal false, schema[:is_primary_key]
+    end
+
+    test 'every column of a composite primary key is flagged is_primary_key: true' do
+      adapter = SchemaAdapter.new(BelongsToField)
+      BelongsToField.define_singleton_method(:primary_key) { ['id', 'has_one_field_id'] }
+      is_pk = ->(name) do
+        adapter.send(:get_schema_for_column, BelongsToField.columns_hash[name])[:is_primary_key]
+      end
+
+      assert_equal true, is_pk.call('id')
+      assert_equal true, is_pk.call('has_one_field_id')
+      assert_equal false, is_pk.call('has_many_field_id')
+    ensure
+      BelongsToField.singleton_class.send(:remove_method, :primary_key)
+    end
+
+    test 'an association is flagged is_primary_key: false' do
+      adapter = SchemaAdapter.new(HasOneField)
+      association = HasOneField.reflect_on_association(:belongs_to_field)
+      schema = adapter.send(:get_schema_for_association, association)
+      assert_equal false, schema[:is_primary_key]
+    end
+
     test 'belongsTo relationship' do
       schema = SchemaAdapter.new(BelongsToField).perform
       fields = schema.fields.select do |field|


### PR DESCRIPTION
## Problem

Forest Admin workflows in **Orchestrator** mode (run by the workflow-executor) fail on a simple read-record with:

> Collection "Author" has no primary key field in its rendering layout. Workflow runs cannot operate on collections without an addressable primary key.

**Browser** mode works, Orchestrator does not.

## Root cause

The SaaS (`workflow-orchestrator/collection-schema`) derives the primary key from the `is_primary_key` flag in the schema pushed by the agent. The gem **never emits** `is_primary_key`, so the SaaS finds no addressable PK for **any** collection of a Ruby agent.

## Fix

Emit `is_primary_key` (boolean) on every column field, `true` only for the column(s) composing the ActiveRecord primary key (handles composite PKs via `composite_primary_keys` where `primary_key` returns an `Array`, and the `nil` case). Default `false` everywhere else, associations included.

### 5 places kept consistent
- **`schema_adapter.rb`** — computed in `get_schema_for_column`; `false` on every association path (`get_schema_for_association`, the inline polymorphic hash, and the FK→association reuse path in `add_associations`).
- **`apimap_sorter.rb`** — whitelisted in `KEYS_COLLECTION_FIELD`. The schema sent to the SaaS goes through `send_apimap → SchemaSerializer → ApimapSorter#reorder_collection_fields → POST /forest/apimaps`, which `slice`s by this list; an unlisted key is **stripped** in both dev and prod.
- **`lib/forest_liana/collection.rb`** (the `field` DSL) — default `false` for scalar smart fields (these are defaulted here, not in `init_properties_with_default`).
- **`schema_file_updater.rb`** — whitelist + default `false` for the `.forestadmin-schema.json` file.
- **`model/collection.rb`** — default `false` for the `Collection.new(fields:)` path.

## Tests
- New minitest cases: standard PK column → `true`, non-PK column → `false`, composite PK → `true` on each PK column, association → `false`. Assertions on the exact flag value; tests call `get_schema_for_column`/`get_schema_for_association` directly to avoid polluting the shared global apimap.
- Updated snapshot specs (`schema_adapter_spec` addressable field, `collection_spec` smart field).
- Full suite green locally: `rake test` 19/0, `rspec` 419/0.

## Notes
- Scope strictly limited to the `is_primary_key` flag.
- A pre-existing `Gemfile.lock` inconsistency on `main` was noticed (`Gemfile` pins `minitest ~> 5.25` but the lock has `6.0.1`); **not** touched here — worth a separate change.

Ref: PRD-439

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Emit `is_primary_key` flag on all collection fields in the schema
> - Adds `is_primary_key` to every field hash in the generated schema: `true` for columns that are part of the model's primary key (including composite keys), `false` for all other columns and association fields.
> - Introduces a `primary_key?` helper in [`SchemaAdapter`](https://github.com/ForestAdmin/forest-rails/pull/772/files#diff-1eae726941328a7d207dbdfd5b67365d6c4f37e62752bdbf68e8d4f1e2a4b4cf) that handles both singular and array primary key values.
> - Updates [`ApimapSorter`](https://github.com/ForestAdmin/forest-rails/pull/772/files#diff-177c72307171d214d6643440839f8baadc48cc38dbb7d59ae5b19714f18ebd6b) and [`SchemaFileUpdater`](https://github.com/ForestAdmin/forest-rails/pull/772/files#diff-751b9fd2ad74012cdd14b46e1779db0e2339f03161f642da3f093a779548b9fa) to include `is_primary_key` in their field key whitelists so the flag is retained and written to the schema file.
> - Smart fields defined via `ForestLiana::Collection.field` also default to `is_primary_key: false`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 025a424.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->