### PR TITLE
fix(engine): prevent boot crash when Rake is partially loaded

### DIFF
--- a/lib/forest_liana/engine.rb
+++ b/lib/forest_liana/engine.rb
@@ -64,7 +64,11 @@ module ForestLiana
       #         models mid-migration (crashing on enums backed by a pending column).
       return true if File.basename($0) == 'rake'
 
-      defined?(Rake) && Rake.application.top_level_tasks.any? { |task| task != 'default' }
+      # NOTICE: `respond_to?` guard — the Rake constant can be defined with only a
+      #         partial load (Rails' test_unit requires rake/file_list), leaving
+      #         Rake.application undefined and crashing boot.
+      defined?(Rake) && Rake.respond_to?(:application) &&
+        Rake.application.top_level_tasks.any? { |task| task != 'default' }
     end
 
     def database_available?

--- a/spec/lib/forest_liana/engine_spec.rb
+++ b/spec/lib/forest_liana/engine_spec.rb
@@ -45,6 +45,24 @@ module ForestLiana
           expect(engine.rake?).to be(false)
         end
       end
+
+      context 'when Rake is only partially loaded (Rake constant defined without Rake.application)' do
+        # Reproduces the boot crash: Rails' test_unit integration requires
+        # `rake/file_list`, which defines the Rake module without loading
+        # rake/application. `defined?(Rake)` is then truthy but `Rake.application`
+        # is undefined, so the old guard raised NoMethodError at boot.
+        it 'returns false instead of raising NoMethodError' do
+          $0 = '/usr/local/bin/rails'
+          allow(Rake).to receive(:respond_to?).and_call_original
+          allow(Rake).to receive(:respond_to?).with(:application).and_return(false)
+          allow(Rake).to receive(:application).and_raise(
+            NoMethodError.new("undefined method 'application' for module Rake")
+          )
+
+          expect { engine.rake? }.not_to raise_error
+          expect(engine.rake?).to be(false)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem
The agent crashes at boot with:
`undefined method 'application' for module Rake (NoMethodError)` in `engine.rb` `#rake?`.

## Root cause
Rails' test_unit integration loads `rails/test_unit/runner.rb`, which does
`require "rake/file_list"`. That pulls in `rake/cloneable`, defining the `Rake`
module **without** loading `rake/application`. So at `after_initialize`:
- `defined?(Rake)` → truthy (constant exists)
- `Rake.application` → **undefined** → NoMethodError

The `defined?(Rake)` guard wrongly assumes "constant present ⇒ `Rake.application` present".
This is not Ruby-version specific (the partial load behaves identically on Ruby 3.1→4.0);
it surfaces whenever the boot path loads `rake/file_list` without full rake.

## Fix
Add an explicit `Rake.respond_to?(:application)` guard.

## Testing
- Regression spec covering the partial-load scenario.
- Verified `demo-rails8` (Rails 8.1 / Ruby 4.0) and `demo-rails` (Rails 7.1) now boot clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix boot crash in `ForestLiana::Engine#rake?` when Rake is partially loaded
> When Rake is partially loaded, `Rake.application` may be undefined, causing a `NoMethodError` on boot. The fix adds a `Rake.respond_to?(:application)` guard in [engine.rb](https://github.com/ForestAdmin/forest-rails/pull/773/files#diff-e88f5a727dabeaecc7222321f358a6bc0711d22f75f4e4cc7aa6f467a32cbe1c) before calling `Rake.application.top_level_tasks`, returning `false` when the check fails. A new spec context in [engine_spec.rb](https://github.com/ForestAdmin/forest-rails/pull/773/files#diff-94dc3de1c1c8c5096e65430e89ba6f1b40e0874883c2f1e0e5d8e21dc3d28040) covers this case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f29600b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->