### PR TITLE
fix(composite-pk): accept pipe-joined composite ids [PRD-450]

### DIFF
--- a/app/services/forest_liana/record_findable.rb
+++ b/app/services/forest_liana/record_findable.rb
@@ -14,13 +14,18 @@ module ForestLiana
       end
     end
 
+    # Composite ids reach us in two shapes, both ordered like the model's primary_key:
+    #   - JSON array "[v1,v2]"  -> from the Forest frontend
+    #   - pipe-joined "v1|v2"   -> from the agent-client (workflow executor, Forest convention)
+    # Either way the values stay in primary_key order, so find_record can zip them directly.
     def parse_composite_id(id)
       return id if id.is_a?(Array)
 
-      if id.to_s.start_with?('[') && id.to_s.end_with?(']')
-        JSON.parse(id.to_s)
+      str = id.to_s
+      if str.start_with?('[') && str.end_with?(']')
+        JSON.parse(str)
       else
-        raise ForestLiana::Errors::HTTP422Error.new("Composite primary key ID must be in format [value1,value2], received: #{id}")
+        str.split('|')
       end
     end
   end

--- a/spec/services/forest_liana/composite_primary_keys_spec.rb
+++ b/spec/services/forest_liana/composite_primary_keys_spec.rb
@@ -30,14 +30,14 @@ module ForestLiana
           expect(helper.parse_composite_id('["a","b"]')).to eq(['a', 'b'])
         end
 
-        it 'returns array as-is when already an array' do
-          expect(helper.parse_composite_id([1, 2])).to eq([1, 2])
+        it 'parses composite ID in pipe-joined format (agent-client / workflow executor)' do
+          expect(helper.parse_composite_id('1|2')).to eq(['1', '2'])
+          expect(helper.parse_composite_id('10|20')).to eq(['10', '20'])
+          expect(helper.parse_composite_id('a|b')).to eq(['a', 'b'])
         end
 
-        it 'raises error for invalid composite ID format' do
-          expect {
-            helper.parse_composite_id('invalid')
-          }.to raise_error(ForestLiana::Errors::HTTP422Error)
+        it 'returns array as-is when already an array' do
+          expect(helper.parse_composite_id([1, 2])).to eq([1, 2])
         end
       end
 


### PR DESCRIPTION
## Problem
The workflow executor (via `@forestadmin/agent-client`) addresses records by a **pipe-joined** composite id (`k1|k2`), but `parse_composite_id` only accepted the **JSON** `[k1,k2]` form the frontend sends and raised `HTTP422` otherwise. As a result, any composite-key **update / by-id** coming from the executor failed with a 422.

## Fix
`parse_composite_id` now accepts **both** shapes:
- JSON array `"[k1,k2]"` — from the Forest frontend
- pipe-joined `"k1|k2"` — from the agent-client (workflow executor, Forest convention)

Both keep the values in `primary_key` order, so `find_record`'s `zip` against `resource.primary_key` is unchanged and the frontend keeps working as before. No serializer/output change.

## Scope
This is the **agent (Ruby) part** of PRD-450. The executor-side fix (reading composite records via the by-id route + related-data) lands in a separate `agent-nodejs` PR.

## Testing
- `composite_primary_keys_spec.rb`: added a pipe-parsing test (the obsolete "raises HTTP422 on invalid format" case is replaced).
- Validated end-to-end: a composite-key `Shipping` workflow (get-data → condition → update-data) now **reads and updates** the record in orchestrator mode — no more `Record not found` / 422.

Relates to PRD-450.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept pipe-joined composite IDs in `RecordFindable.parse_composite_id`
> Previously, `parse_composite_id` only accepted JSON array strings and raised `HTTP422Error` for any other format. It now also splits on `|` for pipe-joined IDs (e.g. `"v1|v2"`), returning an array of string values. The spec in [composite_primary_keys_spec.rb](https://github.com/ForestAdmin/forest-rails/pull/774/files#diff-fc1f76b54ca665ba43044d12c8b28e0405a58c8da95407cf2705008c2c3e0f9b) is updated to cover both formats and removes the test expecting an error on non-JSON input.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 120ea57. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->