### PR TITLE
fix(schema): keep is_primary_key on FK columns composing a composite PK

### DIFF
--- a/app/services/forest_liana/schema_adapter.rb
+++ b/app/services/forest_liana/schema_adapter.rb
@@ -279,7 +279,8 @@ module ForestLiana
               field[:field] = association.name
               field[:inverse_of] = inverse_of(association)
               field[:relationship] = get_relationship_type(association)
-              field[:is_primary_key] = false
+              # NOTICE: Preserve is_primary_key from the underlying column; a
+              #         composite PK made of FKs would otherwise lose its flag.
 
               ForestLiana::SchemaUtils.disable_filter_and_sort_if_cross_db!(
                 field,

--- a/test/services/forest_liana/schema_adapter_test.rb
+++ b/test/services/forest_liana/schema_adapter_test.rb
@@ -69,6 +69,23 @@ module ForestLiana
       assert_equal false, schema[:is_primary_key]
     end
 
+    test 'a foreign key composing the primary key keeps is_primary_key: true once turned into an association' do
+      name = ForestLiana.name_for(BelongsToField)
+      original = ForestLiana.apimap.find { |c| c.name.to_s == name }
+      ForestLiana.apimap.delete(original) if original
+      BelongsToField.define_singleton_method(:primary_key) { ['id', 'has_one_field_id'] }
+
+      schema = SchemaAdapter.new(BelongsToField).perform
+      field = schema.fields.find { |f| f[:field] == :has_one_field }
+
+      assert_equal true, field[:is_primary_key]
+    ensure
+      BelongsToField.singleton_class.send(:remove_method, :primary_key)
+      rebuilt = ForestLiana.apimap.find { |c| c.name.to_s == name }
+      ForestLiana.apimap.delete(rebuilt) if rebuilt
+      ForestLiana.apimap << original if original
+    end
+
     test 'belongsTo relationship' do
       schema = SchemaAdapter.new(BelongsToField).perform
       fields = schema.fields.select do |field|


### PR DESCRIPTION
## Problem

Forest Admin workflows in **Orchestrator** mode (run by the workflow-executor) fail on a simple read-record for collections whose **composite primary key is made of foreign keys** (the typical join-table case):

> Collection "BookStock" has no primary key field in its rendering layout. Workflow runs cannot operate on collections without an addressable primary key.

**Browser** mode works; **Orchestrator** mode does not. Reproduced with a `BookStock` model (`self.primary_key = [:library_id, :book_id]`, two FKs to `Book` and `Library`).

## Root cause

Regression introduced by the PRD-439 fix (#772). In `app/services/forest_liana/schema_adapter.rb`:

1. `add_columns` → `get_schema_for_column` correctly computes `is_primary_key: true` for the `library_id` and `book_id` columns (`BookStock.primary_key` returns the Array `["library_id", "book_id"]`).
2. `add_associations` then turns those FKs into belongsTo associations (`library`, `book`). On the field-reuse path, the line added by #772 — `field[:is_primary_key] = false` — **overwrites** the computed `true`.

Result: no field carries `is_primary_key: true`, so the SaaS finds no addressable PK. The simple-PK case (`id`, never an FK) was not affected, which is why it went unnoticed.

## Fix

Remove the unconditional `field[:is_primary_key] = false` on the belongsTo field-reuse path in `add_associations`. The field already carries the correct value computed by `get_schema_for_column`; it must not be overwritten. The other paths (inline polymorphic, `get_schema_for_association`) still default to `false`.

## Tests

- New minitest case: an FK composing the PK keeps `is_primary_key: true` once turned into an association — this covers the `add_associations` reuse path, which the existing composite-PK test (calling `get_schema_for_column` directly) did not exercise. The global apimap is saved/restored to avoid pollution from the second `perform`.
- Suite green: `rake test` 20/0, `rspec` (schema_adapter + collection) 8/0.

## Notes

- The `is_primary_key: true` flag is now carried by the **association** fields (`library`, `book`). Composite-ID addressing on the executor/SaaS side relies on pipe-joined IDs (see #774 / PRD-450) — to be validated end-to-end.
- Pre-existing simplecov/minitest environment issue (`SimpleCov.external_at_exit=`) worked around locally with `MT_NO_PLUGINS=1`; related to the Gemfile.lock/minitest inconsistency already noted in #772.

Ref: PRD-476

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `is_primary_key` being cleared on FK columns that compose a composite primary key
> In `SchemaAdapter#perform`, association fields derived from foreign-key columns were unconditionally setting `is_primary_key: false`, which incorrectly overrode the flag for FK columns that are also part of a composite primary key. The fix removes that forced assignment so the original primary key flag from the underlying column is preserved. A new test in [schema_adapter_test.rb](https://github.com/ForestAdmin/forest-rails/pull/775/files#diff-70cad5c1b1386a08c735fff2757f5d6d8555c9bb492fc0a1361df427fb1dc9b0) covers the composite PK case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8761e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->