### PR TITLE
feat(schema): expose polymorphic discriminator column (foreign_key_type_field)

### DIFF
--- a/app/services/forest_liana/apimap_sorter.rb
+++ b/app/services/forest_liana/apimap_sorter.rb
@@ -31,6 +31,7 @@ module ForestLiana
       'widget',
       'validations',
       'polymorphic_referenced_models',
+      'foreign_key_type_field',
     ]
     KEYS_ACTION = [
       'name',

--- a/app/services/forest_liana/schema_adapter.rb
+++ b/app/services/forest_liana/schema_adapter.rb
@@ -259,7 +259,10 @@ module ForestLiana
               relationships: nil,
               widget: nil,
               validations: [],
-              polymorphic_referenced_models: get_polymorphic_types(association)
+              polymorphic_referenced_models: get_polymorphic_types(association),
+              # NOTICE: Expose the discriminator column (e.g. "addressable_type")
+              #         so consumers can resolve which model a record targets.
+              foreign_key_type_field: association.foreign_type
             }
 
             collection.fields = collection.fields.reject do |field|

--- a/lib/forest_liana/schema_file_updater.rb
+++ b/lib/forest_liana/schema_file_updater.rb
@@ -37,6 +37,7 @@ module ForestLiana
       'widget',
       'validations',
       'polymorphic_referenced_models',
+      'foreign_key_type_field',
     ]
     KEYS_VALIDATION = [
       'message',

--- a/spec/lib/forest_liana/schema_file_updater_spec.rb
+++ b/spec/lib/forest_liana/schema_file_updater_spec.rb
@@ -32,7 +32,8 @@ module ForestLiana
                     "relationships" => nil,
                     "widget" => nil,
                     "validations" => [],
-                    "polymorphic_referenced_models" => ["User"]
+                    "polymorphic_referenced_models" => ["User"],
+                    "foreign_key_type_field" => "addressable_type"
                   },
                 ],
                 "actions" => [],

--- a/spec/services/forest_liana/schema_adapter_spec.rb
+++ b/spec/services/forest_liana/schema_adapter_spec.rb
@@ -26,7 +26,8 @@ module ForestLiana
               relationships: nil,
               widget: nil,
               validations: [],
-              polymorphic_referenced_models: ['User']
+              polymorphic_referenced_models: ['User'],
+              foreign_key_type_field: 'addressable_type'
             }
           )
         end


### PR DESCRIPTION
## Problem
For polymorphic `belongs_to` relations, the generated schema exposed the list of
target models (`polymorphic_referenced_models`) but **not the name of the
discriminator column** (the `_type`, e.g. `addressable_type`). Downstream, the
workflow orchestrator / executor has no way to know which column carries the
target model, so resolving a polymorphic relation (e.g. *load-related*) fails.

## Fix
On the polymorphic association field of the schema, add a key exposing the
discriminator column name:

```ruby
foreign_key_type_field: association.foreign_type   # e.g. "addressable_type"
```

The key is whitelisted in the two field-key filters so it survives emission /
file writing:
- `ApimapSorter::KEYS_COLLECTION_FIELD`
- `SchemaFileUpdater::KEYS_COLLECTION_FIELD`

## Scope
This is the **forest-rails (v1 agent) part** of PRD-493. The raw `_id` / `_type`
columns are still intentionally removed from the schema (they must not surface
as frontend columns); only the discriminator column **name** is exposed as
relation metadata. The orchestrator and workflow-executor sides land in separate
PRs (forestadmin-server #8286, agent-nodejs #1640).

## Testing
- `schema_adapter_spec.rb`: the polymorphic `addressable` field now asserts
  `foreign_key_type_field: "addressable_type"`.
- `schema_file_updater_spec.rb`: fixture extended with the new key to confirm it
  is preserved through the slice.
- Both specs green.

Relates to [PRD-493](https://linear.app/forestadmin/issue/PRD-493/workflow-orchestrator-load-related-on-a-polymorphic-relation-crashes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `foreign_key_type_field` for polymorphic associations in the schema
> - Adds `foreign_key_type_field` (e.g. `addressable_type`) to the field hash produced by [`SchemaAdapter`](https://github.com/ForestAdmin/forest-rails/pull/776/files#diff-1eae726941328a7d207dbdfd5b67365d6c4f37e62752bdbf68e8d4f1e2a4b4cf) for polymorphic associations, alongside the existing `polymorphic_referenced_models`.
> - Updates the allowed key lists in [`ApimapSorter`](https://github.com/ForestAdmin/forest-rails/pull/776/files#diff-177c72307171d214d6643440839f8baadc48cc38dbb7d59ae5b19714f18ebd6b) and [`SchemaFileUpdater`](https://github.com/ForestAdmin/forest-rails/pull/776/files#diff-751b9fd2ad74012cdd14b46e1779db0e2339f03161f642da3f093a779548b9fa) so the new key is retained and ordered consistently when sorting or writing schema files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c67fa7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->