### PR TITLE
refactor(workflow): forward workflow executor routes generically [PRD-567]

### DIFF
--- a/app/controllers/forest_liana/workflow_executions_controller.rb
+++ b/app/controllers/forest_liana/workflow_executions_controller.rb
@@ -2,8 +2,18 @@ require 'httparty'
 
 module ForestLiana
   class WorkflowExecutionsController < ApplicationController
-    FORWARDED_HEADERS = %w[Authorization Cookie].freeze
-    UPSTREAM_TIMEOUT_IN_SECONDS = 10
+    EXECUTOR_PREFIX = '/runs'.freeze
+    # Hop-by-hop headers + those the HTTP client / framework recomputes — never forwarded
+    # (request or response side).
+    SKIPPED_HEADERS = %w[
+      connection keep-alive transfer-encoding upgrade te trailer
+      proxy-authenticate proxy-authorization host content-length
+    ].freeze
+    # Substrings that could let the wildcard escape EXECUTOR_PREFIX (traversal, encoded dots,
+    # backslash, null byte).
+    UNSAFE_PATH_FRAGMENTS = ['..', '%2e', '%2E', '\\', "\0"].freeze
+    OPEN_TIMEOUT_IN_SECONDS = 2
+    REQUEST_TIMEOUT_IN_SECONDS = 120
     UPSTREAM_ERRORS = [
       HTTParty::Error,
       SocketError,
@@ -13,59 +23,96 @@ module ForestLiana
       Timeout::Error
     ].freeze
 
-    def show
-      forward_to_executor(method: :get, suffix: '')
-    end
-
-    def trigger
-      forward_to_executor(method: :post, suffix: '/trigger')
-    end
-
-    private
-
-    def forward_to_executor(method:, suffix:)
+    # Single catch-all: any sub-path/verb under the agent prefix is forwarded to EXECUTOR_PREFIX,
+    # so a new executor route needs no change here (PRD-567).
+    def proxy
       base = ForestLiana.workflow_executor_url
-      if base.blank?
-        head :not_found
-        return
-      end
+      return head(:not_found) if base.blank?
 
-      url = "#{base.sub(%r{/+\z}, '')}/runs/#{params[:run_id]}#{suffix}"
+      path = safe_executor_path
+      return head(:not_found) if path.nil?
+
       response = HTTParty.send(
-        method,
-        url,
-        headers: forwarded_headers,
+        request.request_method_symbol,
+        "#{base.sub(%r{/+\z}, '')}#{path}",
+        headers: forwarded_request_headers,
         query: forwarded_query,
-        body: forwarded_body(method),
+        body: forwarded_body,
         verify: Rails.env.production?,
-        timeout: UPSTREAM_TIMEOUT_IN_SECONDS
+        open_timeout: OPEN_TIMEOUT_IN_SECONDS,
+        timeout: REQUEST_TIMEOUT_IN_SECONDS
       )
 
+      forward_response_headers(response)
       render json: response.parsed_response, status: response.code
     rescue *UPSTREAM_ERRORS => e
       Rails.logger.error("[ForestLiana] workflow executor proxy error: #{e.class}: #{e.message}")
       render json: { error: 'workflow_executor_unreachable' }, status: :service_unavailable
     end
 
-    def forwarded_headers
-      base = { 'Content-Type' => 'application/json' }
-      FORWARDED_HEADERS.each_with_object(base) do |name, acc|
-        value = request.headers[name]
-        acc[name] = value if value.present?
+    private
+
+    # Security boundary: the wildcard can only ever map into EXECUTOR_PREFIX. Returns nil for
+    # anything that could escape it, so executor routes outside EXECUTOR_PREFIX stay unreachable
+    # through the proxy.
+    def safe_executor_path
+      wildcard = params[:path].to_s
+      return nil if wildcard.empty? || wildcard.start_with?('/')
+      return nil if UNSAFE_PATH_FRAGMENTS.any? { |fragment| wildcard.include?(fragment) }
+
+      "#{EXECUTOR_PREFIX}/#{wildcard}"
+    end
+
+    # Forward every client header except hop-by-hop / host / content-length, so a new executor
+    # header never requires an agent change.
+    def forwarded_request_headers
+      request.headers.env.each_with_object({}) do |(key, value), acc|
+        name = http_header_name(key.to_s)
+        next unless name
+        next if SKIPPED_HEADERS.include?(name.downcase)
+        next if value.nil? || value.to_s.empty?
+
+        acc[name] = value.to_s
       end
     end
 
+    def http_header_name(env_key)
+      if env_key.start_with?('HTTP_')
+        titleize_header(env_key.delete_prefix('HTTP_'))
+      elsif %w[CONTENT_TYPE CONTENT_LENGTH].include?(env_key)
+        titleize_header(env_key)
+      end
+    end
+
+    def titleize_header(rack_name)
+      rack_name.split('_').map(&:capitalize).join('-')
+    end
+
+    # The glob is the routing key; strip it (and Rails internals) so only real query params reach
+    # the executor.
     def forwarded_query
       params
-        .except(:run_id, :controller, :action, :format)
+        .except(:path, :controller, :action, :format)
         .to_unsafe_h
     end
 
-    def forwarded_body(method)
-      return nil if method == :get
+    def forwarded_body
+      return nil if request.get? || request.head?
 
-      raw = request.raw_post
-      raw.presence
+      request.raw_post.presence
+    end
+
+    # Forward every executor response header except hop-by-hop ones, so new executor headers never
+    # require an agent change (PRD-567: zero breaking, the agent stays a transparent proxy).
+    def forward_response_headers(upstream_response)
+      upstream_response.headers.each do |name, value|
+        next if name.nil? || SKIPPED_HEADERS.include?(name.to_s.downcase)
+
+        forwarded = value.is_a?(Array) ? value.join(', ') : value.to_s
+        next if forwarded.empty?
+
+        response.headers[name.to_s] = forwarded
+      end
     end
   end
 end

--- a/app/controllers/forest_liana/workflow_executions_controller.rb
+++ b/app/controllers/forest_liana/workflow_executions_controller.rb
@@ -3,14 +3,11 @@ require 'httparty'
 module ForestLiana
   class WorkflowExecutionsController < ApplicationController
     EXECUTOR_PREFIX = '/runs'.freeze
-    # Hop-by-hop headers + those the HTTP client / framework recomputes — never forwarded
-    # (request or response side).
+    # Hop-by-hop / client-recomputed headers — never forwarded (request or response side).
     SKIPPED_HEADERS = %w[
       connection keep-alive transfer-encoding upgrade te trailer
       proxy-authenticate proxy-authorization host content-length
     ].freeze
-    # Substrings that could let the wildcard escape EXECUTOR_PREFIX (traversal, encoded dots,
-    # backslash, null byte).
     UNSAFE_PATH_FRAGMENTS = ['..', '%2e', '%2E', '\\', "\0"].freeze
     OPEN_TIMEOUT_IN_SECONDS = 2
     REQUEST_TIMEOUT_IN_SECONDS = 120
@@ -23,8 +20,8 @@ module ForestLiana
       Timeout::Error
     ].freeze
 
-    # Single catch-all: any sub-path/verb under the agent prefix is forwarded to EXECUTOR_PREFIX,
-    # so a new executor route needs no change here (PRD-567).
+    # Catch-all: forward any verb/sub-path to EXECUTOR_PREFIX so a new executor route needs no
+    # change here (PRD-567).
     def proxy
       base = ForestLiana.workflow_executor_url
       return head(:not_found) if base.blank?
@@ -52,9 +49,8 @@ module ForestLiana
 
     private
 
-    # Security boundary: the wildcard can only ever map into EXECUTOR_PREFIX. Returns nil for
-    # anything that could escape it, so executor routes outside EXECUTOR_PREFIX stay unreachable
-    # through the proxy.
+    # Security boundary: the wildcard can only map into EXECUTOR_PREFIX; reject (nil) anything that
+    # could escape it, so non-/runs executor routes stay unreachable through the proxy.
     def safe_executor_path
       wildcard = params[:path].to_s
       return nil if wildcard.empty? || wildcard.start_with?('/')
@@ -63,8 +59,6 @@ module ForestLiana
       "#{EXECUTOR_PREFIX}/#{wildcard}"
     end
 
-    # Forward every client header except hop-by-hop / host / content-length, so a new executor
-    # header never requires an agent change.
     def forwarded_request_headers
       request.headers.env.each_with_object({}) do |(key, value), acc|
         name = http_header_name(key.to_s)
@@ -88,8 +82,7 @@ module ForestLiana
       rack_name.split('_').map(&:capitalize).join('-')
     end
 
-    # The glob is the routing key; strip it (and Rails internals) so only real query params reach
-    # the executor.
+    # Strip the routing key (the glob) and Rails internals so only real query params reach the executor.
     def forwarded_query
       params
         .except(:path, :controller, :action, :format)
@@ -102,8 +95,7 @@ module ForestLiana
       request.raw_post.presence
     end
 
-    # Forward every executor response header except hop-by-hop ones, so new executor headers never
-    # require an agent change (PRD-567: zero breaking, the agent stays a transparent proxy).
+    # Forward executor response headers (minus hop-by-hop) so executor-set headers survive the proxy.
     def forward_response_headers(upstream_response)
       upstream_response.headers.each do |name, value|
         next if name.nil? || SKIPPED_HEADERS.include?(name.to_s.downcase)

--- a/app/controllers/forest_liana/workflow_executions_controller.rb
+++ b/app/controllers/forest_liana/workflow_executions_controller.rb
@@ -3,10 +3,13 @@ require 'httparty'
 module ForestLiana
   class WorkflowExecutionsController < ApplicationController
     EXECUTOR_PREFIX = '/runs'.freeze
-    # Hop-by-hop / client-recomputed headers — never forwarded (request or response side).
+    # Never forwarded (request or response): hop-by-hop, Host, and body-framing headers.
+    # render json: re-serializes the body, so the upstream length/encoding no longer match — and
+    # forwarding accept-encoding would defeat Net::HTTP's transparent gzip decompression.
     SKIPPED_HEADERS = %w[
       connection keep-alive transfer-encoding upgrade te trailer
-      proxy-authenticate proxy-authorization host content-length
+      proxy-authenticate proxy-authorization host
+      content-length content-encoding accept-encoding
     ].freeze
     UNSAFE_PATH_FRAGMENTS = ['..', '%2e', '%2E', '\\', "\0"].freeze
     OPEN_TIMEOUT_IN_SECONDS = 2
@@ -17,7 +20,8 @@ module ForestLiana
       Errno::ECONNREFUSED,
       Net::OpenTimeout,
       Net::ReadTimeout,
-      Timeout::Error
+      Timeout::Error,
+      OpenSSL::SSL::SSLError
     ].freeze
 
     # Catch-all: forward any verb/sub-path to EXECUTOR_PREFIX so a new executor route needs no

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,10 +23,11 @@ ForestLiana::Engine.routes.draw do
   # Scopes
   post '/scope-cache-invalidation' => 'scopes#invalidate_scope_cache'
 
-  # Workflow executor proxy (mounted only when ForestLiana.workflow_executor_url is set)
+  # Workflow executor proxy (mounted only when ForestLiana.workflow_executor_url is set).
+  # Single catch-all forwarding every verb/sub-path so a new executor route needs no change
+  # here (PRD-567).
   if ForestLiana.workflow_executor_url.present?
-    get  '_internal/workflow-executions/:run_id'         => 'workflow_executions#show'
-    post '_internal/workflow-executions/:run_id/trigger' => 'workflow_executions#trigger'
+    match '_internal/workflow-executions/*path' => 'workflow_executions#proxy', via: :all
   end
 
   # Stripe Integration

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,9 +23,8 @@ ForestLiana::Engine.routes.draw do
   # Scopes
   post '/scope-cache-invalidation' => 'scopes#invalidate_scope_cache'
 
-  # Workflow executor proxy (mounted only when ForestLiana.workflow_executor_url is set).
-  # Single catch-all forwarding every verb/sub-path so a new executor route needs no change
-  # here (PRD-567).
+  # Workflow executor proxy: single catch-all forwarding every verb/sub-path (PRD-567).
+  # Mounted only when ForestLiana.workflow_executor_url is set.
   if ForestLiana.workflow_executor_url.present?
     match '_internal/workflow-executions/*path' => 'workflow_executions#proxy', via: :all
   end

--- a/spec/requests/workflow_executions_spec.rb
+++ b/spec/requests/workflow_executions_spec.rb
@@ -31,7 +31,14 @@ describe 'Workflow executor proxy', type: :request do
     instance_double(
       HTTParty::Response,
       parsed_response: { 'id' => run_id, 'state' => 'pending' },
-      code: 200
+      code: 200,
+      headers: {
+        'content-type' => 'application/json',
+        # arbitrary executor response header — must be forwarded untouched.
+        'x-executor-custom' => 'passthrough-value',
+        # hop-by-hop response header — must be dropped, not forwarded.
+        'transfer-encoding' => 'chunked'
+      }
     )
   end
 
@@ -42,20 +49,53 @@ describe 'Workflow executor proxy', type: :request do
 
     allow(HTTParty).to receive(:get).and_return(executor_response)
     allow(HTTParty).to receive(:post).and_return(executor_response)
+    allow(HTTParty).to receive(:delete).and_return(executor_response)
   end
 
-  describe 'GET /forest/_internal/workflow-executions/:run_id' do
-    it 'forwards GET to the executor /runs/:run_id endpoint' do
+  describe 'generic forwarding' do
+    it 'forwards a GET under /runs, preserving the sub-path and query verbatim' do
       get "/forest/_internal/workflow-executions/#{run_id}", params: { foo: 'bar' }, headers: auth_headers
 
       expect(HTTParty).to have_received(:get).with(
         "#{executor_url}/runs/#{run_id}",
+        hash_including(query: hash_including('foo' => 'bar'))
+      )
+    end
+
+    it 'forwards a POST trigger with the raw body untouched (no reshaping)' do
+      raw = { step: 'approve', value: 42 }.to_json
+
+      post(
+        "/forest/_internal/workflow-executions/#{run_id}/trigger",
+        params: raw,
+        headers: auth_headers
+      )
+
+      expect(HTTParty).to have_received(:post).with(
+        "#{executor_url}/runs/#{run_id}/trigger",
+        hash_including(body: raw)
+      )
+    end
+
+    it 'forwards any verb and any future sub-path without a dedicated route' do
+      delete "/forest/_internal/workflow-executions/#{run_id}/cancel", headers: auth_headers
+
+      expect(HTTParty).to have_received(:delete).with(
+        "#{executor_url}/runs/#{run_id}/cancel",
+        anything
+      )
+    end
+
+    it 'forwards client headers (e.g. Authorization / Cookie) to the executor' do
+      get "/forest/_internal/workflow-executions/#{run_id}", headers: auth_headers
+
+      expect(HTTParty).to have_received(:get).with(
+        anything,
         hash_including(
           headers: hash_including(
             'Authorization' => "Bearer #{bearer_token}",
             'Cookie' => 'forest_session_token=session-xyz'
-          ),
-          query: hash_including('foo' => 'bar')
+          )
         )
       )
     end
@@ -67,6 +107,31 @@ describe 'Workflow executor proxy', type: :request do
       expect(JSON.parse(response.body)).to eq('id' => run_id, 'state' => 'pending')
     end
 
+    it 'forwards executor response headers except hop-by-hop ones' do
+      get "/forest/_internal/workflow-executions/#{run_id}", headers: auth_headers
+
+      expect(response.headers['x-executor-custom']).to eq('passthrough-value')
+      expect(response.headers['transfer-encoding']).to be_nil
+    end
+  end
+
+  describe 'path traversal protection (the namespace security boundary)' do
+    [
+      '..',
+      '../mcp-oauth-credentials',
+      "#{'run_abc123'}/../../mcp-oauth-credentials",
+      '%2e%2e/mcp-oauth-credentials'
+    ].each do |evil_path|
+      it "rejects #{evil_path.inspect} with 404 and never forwards" do
+        get "/forest/_internal/workflow-executions/#{evil_path}", headers: auth_headers
+
+        expect(response.status).to eq(404)
+        expect(HTTParty).not_to have_received(:get)
+      end
+    end
+  end
+
+  describe 'authentication' do
     it 'rejects unauthenticated requests with 401' do
       get "/forest/_internal/workflow-executions/#{run_id}"
 
@@ -75,40 +140,14 @@ describe 'Workflow executor proxy', type: :request do
     end
   end
 
-  describe 'POST /forest/_internal/workflow-executions/:run_id/trigger' do
-    let(:trigger_body) { { step: 'approve', value: 42 } }
-
-    it 'forwards POST to the executor /runs/:run_id/trigger endpoint with the body' do
-      post(
-        "/forest/_internal/workflow-executions/#{run_id}/trigger",
-        params: trigger_body.to_json,
-        headers: auth_headers
-      )
-
-      expect(HTTParty).to have_received(:post).with(
-        "#{executor_url}/runs/#{run_id}/trigger",
-        hash_including(
-          headers: hash_including('Authorization' => "Bearer #{bearer_token}"),
-          body: trigger_body.to_json
-        )
-      )
-    end
-
-    it 'returns the executor response' do
-      post(
-        "/forest/_internal/workflow-executions/#{run_id}/trigger",
-        params: trigger_body.to_json,
-        headers: auth_headers
-      )
-
-      expect(response.status).to eq(200)
-      expect(JSON.parse(response.body)).to eq('id' => run_id, 'state' => 'pending')
-    end
-  end
-
   describe 'when the executor returns an error status' do
     let(:executor_response) do
-      instance_double(HTTParty::Response, parsed_response: { 'error' => 'invalid_step' }, code: 422)
+      instance_double(
+        HTTParty::Response,
+        parsed_response: { 'error' => 'invalid_step' },
+        code: 422,
+        headers: { 'content-type' => 'application/json' }
+      )
     end
 
     it 'forwards the executor status and body to the client' do

--- a/spec/requests/workflow_executions_spec.rb
+++ b/spec/requests/workflow_executions_spec.rb
@@ -37,7 +37,9 @@ describe 'Workflow executor proxy', type: :request do
         # arbitrary executor response header — must be forwarded untouched.
         'x-executor-custom' => 'passthrough-value',
         # hop-by-hop response header — must be dropped, not forwarded.
-        'transfer-encoding' => 'chunked'
+        'transfer-encoding' => 'chunked',
+        # body-framing header — meaningless once the body is re-serialized; must be dropped.
+        'content-encoding' => 'gzip'
       }
     )
   end
@@ -107,11 +109,23 @@ describe 'Workflow executor proxy', type: :request do
       expect(JSON.parse(response.body)).to eq('id' => run_id, 'state' => 'pending')
     end
 
-    it 'forwards executor response headers except hop-by-hop ones' do
+    it 'forwards executor response headers except hop-by-hop / encoding ones' do
       get "/forest/_internal/workflow-executions/#{run_id}", headers: auth_headers
 
       expect(response.headers['x-executor-custom']).to eq('passthrough-value')
       expect(response.headers['transfer-encoding']).to be_nil
+      # content-encoding would tell the client the re-serialized JSON is gzipped → corruption.
+      expect(response.headers['content-encoding']).to be_nil
+    end
+
+    it 'does not forward accept-encoding (would defeat transparent gzip decompression)' do
+      get "/forest/_internal/workflow-executions/#{run_id}",
+          headers: auth_headers.merge('Accept-Encoding' => 'gzip, deflate')
+
+      expect(HTTParty).to have_received(:get).with(
+        anything,
+        hash_including(headers: hash_excluding('Accept-Encoding'))
+      )
     end
   end
 
@@ -164,6 +178,19 @@ describe 'Workflow executor proxy', type: :request do
     end
 
     it 'returns 503 service_unavailable' do
+      get "/forest/_internal/workflow-executions/#{run_id}", headers: auth_headers
+
+      expect(response.status).to eq(503)
+      expect(JSON.parse(response.body)).to eq('error' => 'workflow_executor_unreachable')
+    end
+  end
+
+  describe 'when the executor connection fails at the transport level (e.g. SSL)' do
+    before do
+      allow(HTTParty).to receive(:get).and_raise(OpenSSL::SSL::SSLError.new('cert verify failed'))
+    end
+
+    it 'returns 503 rather than a generic 500' do
       get "/forest/_internal/workflow-executions/#{run_id}", headers: auth_headers
 
       expect(response.status).to eq(503)


### PR DESCRIPTION
## What

Phase 3 (Ruby v1 liana) of PRD-567. Replaces the two explicit `show`/`trigger` proxy routes with a **single catch-all** that forwards every verb and sub-path under `/_internal/workflow-executions/*` to the executor `/runs` namespace. The agent no longer needs a change when the executor adds a route.

Mirrors the Node ([agent-nodejs#1666](https://github.com/ForestAdmin/agent-nodejs/pull/1666)) and Ruby v2 ([agent-ruby#319](https://github.com/ForestAdmin/agent-ruby/pull/319)) implementations.

## Changes

- **Catch-all glob route** (`match '*path', via: :all`) replacing the 2 per-route entries — all verbs.
- **Forward all request headers** except hop-by-hop / host / content-length (was an `Authorization`+`Cookie` whitelist).
- **Forward all response headers** except hop-by-hop — so executor-set headers (e.g. the version gate) survive the proxy instead of being dropped.
- **Raw request body** forwarded untouched.
- **Single large timeout** (open 2s / read 120s), no per-route values.
- **Path-traversal guard**: the wildcard can only map into `/runs` — `..`, encoded dots, backslash, null byte and leading `/` are rejected with 404, keeping non-`/runs` executor routes (e.g. mcp-oauth-credentials) unreachable through the proxy.

## Tests

Rewritten request spec → generic forwarding (arbitrary verb/sub-path), raw body, request + response header filtering, **path-traversal security boundary**, status/error passthrough, 401 unauthenticated, 404 when unconfigured. **14/14 green** under Ruby 3.3.

fixes PRD-567

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace specific workflow executor routes with a generic catch-all proxy for all verbs under `/runs/*`
> - Replaces two fixed routes (`GET /runs/:run_id` and `POST /runs/:run_id/trigger`) with a single catch-all route matching all HTTP verbs under `/_internal/workflow-executions/*path` in [routes.rb](https://github.com/ForestAdmin/forest-rails/pull/777/files#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5).
> - The new `proxy` action in [WorkflowExecutionsController](https://github.com/ForestAdmin/forest-rails/pull/777/files#diff-c4d799f239b33ca99911c5d701d11408d1df0cb69e5a9a8723fdb964d2ec83e0) forwards any verb and sub-path to the executor, including query params, raw body, and request headers (excluding hop-by-hop, Host, and encoding headers).
> - Upstream response headers are now propagated back to the client, and SSL/transport errors return 503.
> - Path traversal attempts (empty, absolute, or `..`-containing paths) are rejected with 404 via `safe_executor_path`.
> - Behavioral Change: open timeout is 2s and overall request timeout is 120s; `OpenSSL::SSL::SSLError` is now caught and returned as 503.
>
> #### 🖇️ Linked Issues
> Relates to [PRD-567](ticket:linear/PRD-567).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1644bb0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


## Known limitation (by design)

This legacy liana is **JSON-only**: responses are rendered as JSON (`render json: ...`). A hypothetical non-JSON executor response (e.g. `text/plain`) would not pass through verbatim. The executor only returns JSON today, so this does not affect the PRD-567 contract in practice; the `@forestadmin/agent` Node core ([agent-nodejs#1666](https://github.com/ForestAdmin/agent-nodejs/pull/1666)) handles raw passthrough.