### PR TITLE
feat(workflow): forward any executor route generically [PRD-567]

### DIFF
--- a/app/controllers/forest_liana/workflow_executions_controller.rb
+++ b/app/controllers/forest_liana/workflow_executions_controller.rb
@@ -1,8 +1,8 @@
 require 'httparty'
+require 'uri'
 
 module ForestLiana
   class WorkflowExecutionsController < ApplicationController
-    EXECUTOR_PREFIX = '/runs'.freeze
     # Never forwarded (request or response): hop-by-hop, Host, and body-framing headers.
     # render json: re-serializes the body, so the upstream length/encoding no longer match — and
     # forwarding accept-encoding would defeat Net::HTTP's transparent gzip decompression.
@@ -24,22 +24,26 @@ module ForestLiana
       OpenSSL::SSL::SSLError
     ].freeze
 
-    # Catch-all: forward any verb/sub-path to EXECUTOR_PREFIX so a new executor route needs no
-    # change here (PRD-567).
+    # Catch-all: forward any verb/sub-path verbatim to the executor, so a new executor route needs
+    # no change here.
     def proxy
       base = ForestLiana.workflow_executor_url
       return head(:not_found) if base.blank?
 
+      normalized_base = base.sub(%r{/+\z}, '')
       path = safe_executor_path
       return head(:not_found) if path.nil?
+      return head(:not_found) unless same_origin?(normalized_base, path)
 
       response = HTTParty.send(
         request.request_method_symbol,
-        "#{base.sub(%r{/+\z}, '')}#{path}",
+        "#{normalized_base}#{path}",
         headers: forwarded_request_headers,
         query: forwarded_query,
         body: forwarded_body,
         verify: Rails.env.production?,
+        # Don't follow redirects: a 3xx Location to an off-origin host would bypass the origin guard.
+        follow_redirects: false,
         open_timeout: OPEN_TIMEOUT_IN_SECONDS,
         timeout: REQUEST_TIMEOUT_IN_SECONDS
       )
@@ -53,14 +57,22 @@ module ForestLiana
 
     private
 
-    # Security boundary: the wildcard can only map into EXECUTOR_PREFIX; reject (nil) anything that
-    # could escape it, so non-/runs executor routes stay unreachable through the proxy.
+    # First-pass rejection of escape attempts; the authoritative origin check is same_origin?.
     def safe_executor_path
       wildcard = params[:path].to_s
       return nil if wildcard.empty? || wildcard.start_with?('/')
       return nil if UNSAFE_PATH_FRAGMENTS.any? { |fragment| wildcard.include?(fragment) }
 
-      "#{EXECUTOR_PREFIX}/#{wildcard}"
+      "/#{wildcard}"
+    end
+
+    # Authoritative SSRF check: forwarding must never leave the executor origin.
+    def same_origin?(base, path)
+      base_uri = URI.parse(base)
+      target = URI.parse("#{base}#{path}")
+      target.scheme == base_uri.scheme && target.host == base_uri.host && target.port == base_uri.port
+    rescue URI::InvalidURIError
+      false
     end
 
     def forwarded_request_headers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,10 +23,10 @@ ForestLiana::Engine.routes.draw do
   # Scopes
   post '/scope-cache-invalidation' => 'scopes#invalidate_scope_cache'
 
-  # Workflow executor proxy: single catch-all forwarding every verb/sub-path (PRD-567).
+  # Workflow executor proxy: single catch-all forwarding every verb/sub-path verbatim.
   # Mounted only when ForestLiana.workflow_executor_url is set.
   if ForestLiana.workflow_executor_url.present?
-    match '_internal/workflow-executions/*path' => 'workflow_executions#proxy', via: :all
+    match '_internal/executor/*path' => 'workflow_executions#proxy', via: :all
   end
 
   # Stripe Integration

--- a/spec/requests/workflow_executions_spec.rb
+++ b/spec/requests/workflow_executions_spec.rb
@@ -55,8 +55,8 @@ describe 'Workflow executor proxy', type: :request do
   end
 
   describe 'generic forwarding' do
-    it 'forwards a GET under /runs, preserving the sub-path and query verbatim' do
-      get "/forest/_internal/workflow-executions/#{run_id}", params: { foo: 'bar' }, headers: auth_headers
+    it 'forwards a run GET (caller includes runs/), preserving the sub-path and query verbatim' do
+      get "/forest/_internal/executor/runs/#{run_id}", params: { foo: 'bar' }, headers: auth_headers
 
       expect(HTTParty).to have_received(:get).with(
         "#{executor_url}/runs/#{run_id}",
@@ -68,7 +68,7 @@ describe 'Workflow executor proxy', type: :request do
       raw = { step: 'approve', value: 42 }.to_json
 
       post(
-        "/forest/_internal/workflow-executions/#{run_id}/trigger",
+        "/forest/_internal/executor/runs/#{run_id}/trigger",
         params: raw,
         headers: auth_headers
       )
@@ -79,17 +79,17 @@ describe 'Workflow executor proxy', type: :request do
       )
     end
 
-    it 'forwards any verb and any future sub-path without a dedicated route' do
-      delete "/forest/_internal/workflow-executions/#{run_id}/cancel", headers: auth_headers
+    it 'forwards a non-runs route verbatim (no /runs prefix injected)' do
+      delete '/forest/_internal/executor/mcp-oauth-credentials', headers: auth_headers
 
       expect(HTTParty).to have_received(:delete).with(
-        "#{executor_url}/runs/#{run_id}/cancel",
+        "#{executor_url}/mcp-oauth-credentials",
         anything
       )
     end
 
     it 'forwards client headers (e.g. Authorization / Cookie) to the executor' do
-      get "/forest/_internal/workflow-executions/#{run_id}", headers: auth_headers
+      get "/forest/_internal/executor/runs/#{run_id}", headers: auth_headers
 
       expect(HTTParty).to have_received(:get).with(
         anything,
@@ -102,15 +102,24 @@ describe 'Workflow executor proxy', type: :request do
       )
     end
 
+    it 'does not follow redirects (a 3xx Location must not escape the executor origin)' do
+      get "/forest/_internal/executor/runs/#{run_id}", headers: auth_headers
+
+      expect(HTTParty).to have_received(:get).with(
+        anything,
+        hash_including(follow_redirects: false)
+      )
+    end
+
     it 'returns the executor status and body verbatim' do
-      get "/forest/_internal/workflow-executions/#{run_id}", headers: auth_headers
+      get "/forest/_internal/executor/runs/#{run_id}", headers: auth_headers
 
       expect(response.status).to eq(200)
       expect(JSON.parse(response.body)).to eq('id' => run_id, 'state' => 'pending')
     end
 
     it 'forwards executor response headers except hop-by-hop / encoding ones' do
-      get "/forest/_internal/workflow-executions/#{run_id}", headers: auth_headers
+      get "/forest/_internal/executor/runs/#{run_id}", headers: auth_headers
 
       expect(response.headers['x-executor-custom']).to eq('passthrough-value')
       expect(response.headers['transfer-encoding']).to be_nil
@@ -119,7 +128,7 @@ describe 'Workflow executor proxy', type: :request do
     end
 
     it 'does not forward accept-encoding (would defeat transparent gzip decompression)' do
-      get "/forest/_internal/workflow-executions/#{run_id}",
+      get "/forest/_internal/executor/runs/#{run_id}",
           headers: auth_headers.merge('Accept-Encoding' => 'gzip, deflate')
 
       expect(HTTParty).to have_received(:get).with(
@@ -129,7 +138,7 @@ describe 'Workflow executor proxy', type: :request do
     end
   end
 
-  describe 'path traversal protection (the namespace security boundary)' do
+  describe 'SSRF guard (cannot escape the executor origin)' do
     [
       '..',
       '../mcp-oauth-credentials',
@@ -137,7 +146,7 @@ describe 'Workflow executor proxy', type: :request do
       '%2e%2e/mcp-oauth-credentials'
     ].each do |evil_path|
       it "rejects #{evil_path.inspect} with 404 and never forwards" do
-        get "/forest/_internal/workflow-executions/#{evil_path}", headers: auth_headers
+        get "/forest/_internal/executor/#{evil_path}", headers: auth_headers
 
         expect(response.status).to eq(404)
         expect(HTTParty).not_to have_received(:get)
@@ -147,7 +156,7 @@ describe 'Workflow executor proxy', type: :request do
 
   describe 'authentication' do
     it 'rejects unauthenticated requests with 401' do
-      get "/forest/_internal/workflow-executions/#{run_id}"
+      get "/forest/_internal/executor/runs/#{run_id}"
 
       expect(response.status).to eq(401)
       expect(HTTParty).not_to have_received(:get)
@@ -165,7 +174,7 @@ describe 'Workflow executor proxy', type: :request do
     end
 
     it 'forwards the executor status and body to the client' do
-      get "/forest/_internal/workflow-executions/#{run_id}", headers: auth_headers
+      get "/forest/_internal/executor/runs/#{run_id}", headers: auth_headers
 
       expect(response.status).to eq(422)
       expect(JSON.parse(response.body)).to eq('error' => 'invalid_step')
@@ -178,7 +187,7 @@ describe 'Workflow executor proxy', type: :request do
     end
 
     it 'returns 503 service_unavailable' do
-      get "/forest/_internal/workflow-executions/#{run_id}", headers: auth_headers
+      get "/forest/_internal/executor/runs/#{run_id}", headers: auth_headers
 
       expect(response.status).to eq(503)
       expect(JSON.parse(response.body)).to eq('error' => 'workflow_executor_unreachable')
@@ -191,7 +200,7 @@ describe 'Workflow executor proxy', type: :request do
     end
 
     it 'returns 503 rather than a generic 500' do
-      get "/forest/_internal/workflow-executions/#{run_id}", headers: auth_headers
+      get "/forest/_internal/executor/runs/#{run_id}", headers: auth_headers
 
       expect(response.status).to eq(503)
       expect(JSON.parse(response.body)).to eq('error' => 'workflow_executor_unreachable')
@@ -211,7 +220,7 @@ describe 'Workflow executor proxy', type: :request do
       # Note: routes are mounted at boot based on workflow_executor_url being
       # present. This test exercises the runtime guard inside the controller
       # for scenarios where config is mutated after boot (e.g. tests).
-      get "/forest/_internal/workflow-executions/#{run_id}", headers: auth_headers
+      get "/forest/_internal/executor/runs/#{run_id}", headers: auth_headers
 
       expect(response.status).to eq(404)
     end


### PR DESCRIPTION
## What

Ports the generic executor passthrough to forest-rails (Ruby v1 liana), matching the agent-nodejs reference ([agent-nodejs#1707](https://github.com/ForestAdmin/agent-nodejs/pull/1707), 1.81.0).

- **Single catch-all mount** `_internal/executor/*path` → executor `/:path` **verbatim** (all verbs). Replaces the `/runs`-confined proxy. Callers address runs as `runs/<id>`.

## Security

- **SSRF guard**: string guard (empty / leading-`/` / `..` / `%2e`/`%2E` / backslash / NUL → 404) plus a `URI`-based same-origin check (reject unless scheme+host+port match; a control char like `\t//host` makes `URI.parse` raise → 404).
- **`follow_redirects: false`**: HTTParty follows redirects by default — a 3xx `Location` to an off-origin host would bypass the origin guard, so disable it (the Node agent's raw http client never follows redirects).

## Tests

**17/17**. Run GET (caller includes `runs/`), POST trigger, **non-runs route verbatim** (no `/runs` prefix injected), `follow_redirects: false` asserted, header req/resp filtering, status/body passthrough, SSRF vectors → 404, 401 unauthenticated, unreachable/SSL → 503, 404 when unconfigured.

fixes PRD-567

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor `WorkflowExecutionsController` proxy to forward executor routes generically with same-origin enforcement
> - Renames the proxy route from `_internal/workflow-executions/*path` to `_internal/executor/*path` in [config/routes.rb](https://github.com/ForestAdmin/forest-rails/pull/778/files#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5).
> - Removes the automatic `/runs` prefix injection; the proxy now forwards the client-provided sub-path verbatim via `safe_executor_path`.
> - Adds a `same_origin?` helper that parses scheme, host, and port to reject any forwarding target that differs from the configured executor base URL.
> - Sets `follow_redirects: false` in HTTParty to prevent off-origin redirect exploitation.
> - Behavioral Change: any existing clients calling `/forest/_internal/workflow-executions/...` will receive 404; callers must update to `/forest/_internal/executor/...`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d7263f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->