### PR TITLE
test(workflow): gzip passthrough regression for the executor proxy [PRD-567]

### DIFF
--- a/spec/requests/workflow_executions_spec.rb
+++ b/spec/requests/workflow_executions_spec.rb
@@ -1,4 +1,7 @@
 require 'rails_helper'
+require 'zlib'
+require 'stringio'
+require 'socket'
 
 describe 'Workflow executor proxy', type: :request do
   let(:run_id) { 'run_abc123' }
@@ -204,6 +207,53 @@ describe 'Workflow executor proxy', type: :request do
 
       expect(response.status).to eq(503)
       expect(JSON.parse(response.body)).to eq('error' => 'workflow_executor_unreachable')
+    end
+  end
+
+  # Real local server + real HTTParty (no stub) to exercise actual gzip decompression.
+  describe 'when the executor gzip-compresses the response (nginx in front)' do
+    let(:gz_body) do
+      io = StringIO.new
+      writer = Zlib::GzipWriter.new(io)
+      writer.write({ 'id' => run_id, 'state' => 'pending' }.to_json)
+      writer.close
+      io.string
+    end
+
+    around do |example|
+      server = TCPServer.new('127.0.0.1', 0)
+      port = server.addr[1]
+      thread = Thread.new do
+        client = server.accept
+        client.readpartial(4096)
+        client.write(
+          "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n" \
+          "Content-Encoding: gzip\r\nContent-Length: #{gz_body.bytesize}\r\n" \
+          "Connection: close\r\n\r\n"
+        )
+        client.write(gz_body)
+        client.close
+      rescue IOError, Errno::ECONNRESET, Errno::EPIPE
+        nil
+      end
+
+      original = ForestLiana.workflow_executor_url
+      ForestLiana.workflow_executor_url = "http://127.0.0.1:#{port}"
+      example.run
+    ensure
+      ForestLiana.workflow_executor_url = original
+      thread&.kill
+      server&.close
+    end
+
+    before { allow(HTTParty).to receive(:get).and_call_original }
+
+    it 'decompresses the body and drops the stale content-encoding' do
+      get "/forest/_internal/executor/runs/#{run_id}", headers: auth_headers
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)).to eq('id' => run_id, 'state' => 'pending')
+      expect(response.headers['content-encoding']).to be_nil
     end
   end
 


### PR DESCRIPTION
## What

Follow-up test for the generic executor passthrough ([#778](https://github.com/ForestAdmin/forest-rails/pull/778), merged). Locks in the gzip behaviour after the Node bug ([agent-nodejs#1716](https://github.com/ForestAdmin/agent-nodejs/pull/1716)): nginx in front of the executor gzips large responses.

A real local server + **real HTTParty** (no stub) confirm that a gzip-compressed executor response is:
- **decompressed** (Net::HTTP, since we don't forward the client's `Accept-Encoding`), and
- returned **without a stale `Content-Encoding`** (we drop it in `SKIPPED_HEADERS`).

Test-only change. **18/18**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add regression test for gzip passthrough in the executor proxy
> Adds a new RSpec describe block in [workflow_executions_spec.rb](https://github.com/ForestAdmin/forest-rails/pull/779/files#diff-503b3a0bc23d3e8869a161dd258c60baefc89ff1bd0904b1968a14ed2cc59e7e) that spins up a real local TCP server to simulate an upstream executor returning a gzip-compressed response. The test verifies that the proxy controller decompresses the body, returns a 200 with the JSON payload, and strips the `content-encoding` header from the downstream response.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f5e55e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->