### PR TITLE
fix(actions): always expose /hooks/load even without a load hook [PRD-801]

### DIFF
--- a/app/controllers/forest_liana/actions_controller.rb
+++ b/app/controllers/forest_liana/actions_controller.rb
@@ -58,7 +58,7 @@ module ForestLiana
       begin
         # action.hooks[:change] is a hashmap here
         # to do the validation, only the hook names are require
-        change_hooks_name = action.hooks[:change].nil? ? nil : action.hooks[:change].keys
+        change_hooks_name = action.hooks && action.hooks[:change] ? action.hooks[:change].keys : nil
         ForestLiana::SmartActionFieldValidator.validate_smart_action_fields(result[:fields], action.name, change_hooks_name)
       rescue ForestLiana::Errors::SmartActionInvalidFieldError => invalid_field_error
         FOREST_LOGGER.warn invalid_field_error.message
@@ -107,10 +107,15 @@ module ForestLiana
         # Get the smart action hook load context
         context = get_smart_action_load_ctx(action.fields)
 
-        # Call the user-defined load hook.
-        result = action.hooks[:load].(context)
+        if action.hooks && action.hooks[:load].present?
+          # Call the user-defined load hook.
+          result = action.hooks[:load].(context)
 
-        handle_result(result, action)
+          handle_result(result, action)
+        else
+          # No load hook declared: answer the static form (Node agent parity) instead of a 404.
+          handle_result(context[:fields], action)
+        end
       end
     end
 

--- a/config/routes/actions.rb
+++ b/config/routes/actions.rb
@@ -1,9 +1,8 @@
 ForestLiana.apimap.each do |collection|
   if !collection.actions.empty?
     collection.actions.each do |action|
-      if action.hooks && action.hooks[:load].present?
-        post action.endpoint.sub('forest', '') + '/hooks/load' => 'actions#load', action_name: ActiveSupport::Inflector.parameterize(action.name)
-      end
+      # Unconditional: clients probe /hooks/load even when no load hook is declared.
+      post action.endpoint.sub('forest', '') + '/hooks/load' => 'actions#load', action_name: ActiveSupport::Inflector.parameterize(action.name)
       if action.hooks && action.hooks[:change].present?
         post action.endpoint.sub('forest', '') + '/hooks/change' => 'actions#change', action_name: ActiveSupport::Inflector.parameterize(action.name)
       end

--- a/spec/dummy/lib/forest_liana/collections/island.rb
+++ b/spec/dummy/lib/forest_liana/collections/island.rb
@@ -28,6 +28,19 @@ class Forest::Island
 
   action 'test'
 
+  action 'static_form_action',
+    fields: [{
+      field: 'static_field',
+      type: 'String',
+      default_value: nil,
+      enums: nil,
+      is_required: false,
+      is_read_only: false,
+      reference: nil,
+      description: nil,
+      widget: nil
+    }]
+
   action 'my_action',
     fields: [foo],
     hooks: {

--- a/spec/requests/actions_controller_spec.rb
+++ b/spec/requests/actions_controller_spec.rb
@@ -136,6 +136,11 @@ describe 'Requesting Actions routes', :type => :request  do
         static_field = action.fields.select { |field| field[:field] == 'static_field' }.first
         expect(response.status).to eq(200)
         expect(JSON.parse(response.body)).to eq({'fields' => [static_field.merge({:value => nil}).transform_keys { |key| key.to_s.camelize(:lower) }.stringify_keys]})
+
+        first_body = response.body
+        post '/forest/actions/static_form_action/hooks/load', params: JSON.dump(params), headers: headers
+        expect(response.status).to eq(200)
+        expect(response.body).to eq(first_body)
       end
 
       it 'should respond 200 with empty fields when the action has no form at all' do

--- a/spec/requests/actions_controller_spec.rb
+++ b/spec/requests/actions_controller_spec.rb
@@ -130,6 +130,20 @@ describe 'Requesting Actions routes', :type => :request  do
         expect(response.status).to eq(422)
       end
 
+      it 'should respond 200 with the static form when the action has no load hook' do
+        post '/forest/actions/static_form_action/hooks/load', params: JSON.dump(params), headers: headers
+        action = island.actions.select { |action| action.name == 'static_form_action' }.first
+        static_field = action.fields.select { |field| field[:field] == 'static_field' }.first
+        expect(response.status).to eq(200)
+        expect(JSON.parse(response.body)).to eq({'fields' => [static_field.merge({:value => nil}).transform_keys { |key| key.to_s.camelize(:lower) }.stringify_keys]})
+      end
+
+      it 'should respond 200 with empty fields when the action has no form at all' do
+        post '/forest/actions/test/hooks/load', params: JSON.dump(params), headers: headers
+        expect(response.status).to eq(200)
+        expect(JSON.parse(response.body)).to eq({'fields' => []})
+      end
+
       it 'should respond 500 with bad hook result type' do
         post '/forest/actions/fail_action/hooks/load', params: JSON.dump(params), headers: headers
         expect(response.status).to eq(500)


### PR DESCRIPTION
## Context

Clients probe `POST /forest/actions/:action/hooks/load` unconditionally — the frontend when opening an action form, and the workflow executor (via `@forestadmin/agent-client`) when preparing a record-action step. forest_liana only drew that route when the action declared a `load` hook, so every form opening of a hook-less action answered **404**.

Nothing was functionally broken (agent-client swallows the 404 and falls back to the schema's static fields), but the noise is real: at Qonto App Prod, workflow runs produced 202 × `POST /forest/actions/*/hooks/load → 404` in 45 minutes, polluting their HTTP metrics and alerting.

The Node agent already answers this route for every action (returning the static form when no hook is declared) — this PR aligns forest-rails on that behavior.

## Changes

- `config/routes/actions.rb`: the `/hooks/load` route is now drawn for every action (the `hooks/change` route stays conditional).
- `ActionsController#load`: when no load hook is declared, answer the static form (the action's declared fields, same widget/value pipeline as the hook context) with a 200.
- `ActionsController#handle_result`: guard against `action.hooks` being nil (actions with no hooks at all).
- Specs: new `static_form_action` fixture (static form, `change` hooks only — the exact Qonto shape) + 2 request specs (static form → 200 with camelized fields; action with no form → 200 with empty fields).

## Backward compatibility

The URL previously answered 404 and agent-client's fallback only triggers **on** 404, so existing clients keep working — they now simply get the form directly. Actions with a load hook are untouched (verified on a demo app: hook still runs, `widgetEdit` computed, custom endpoints included).

Linear: PRD-801

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Always expose `/hooks/load` route for actions without a load hook
> - The `/hooks/load` POST route is now registered unconditionally for all actions in [actions.rb](https://github.com/ForestAdmin/forest-rails/pull/780/files#diff-2251714258030a8a0e359ad08cbed90a6d11e4f4432cd89054d339ed8b0d6903), instead of only when a load hook is defined.
> - The load handler in [actions_controller.rb](https://github.com/ForestAdmin/forest-rails/pull/780/files#diff-9793da9eadaf93e03cb32dd3baae1f11d9453cda870767db211836668d503314) now returns static form fields when no load hook exists, rather than failing.
> - Change hook name extraction now guards against missing `action.hooks` to avoid validation errors on hookless actions.
>
> #### 🖇️ Linked Issues
> Resolves [PRD-801](ticket:linear/PRD-801).
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #780 opened
>
> - Extended test for `/forest/actions/static_form_action/hooks/load` endpoint to verify idempotent behavior [231466a]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b33325c. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->