### PR TITLE
perf: avoid a SQL query per association in separate_database?

### DIFF
--- a/app/services/forest_liana/base_getter.rb
+++ b/app/services/forest_liana/base_getter.rb
@@ -51,10 +51,8 @@ module ForestLiana
     def separate_database?(resource, association)
       return false if SchemaUtils.polymorphic?(association)
 
-      target_model_connection = association.klass.connection
-      target_model_database = target_model_connection.current_database if target_model_connection.respond_to? :current_database
-      resource_connection = resource.connection
-      resource_database = resource_connection.current_database if resource_connection.respond_to? :current_database
+      target_model_database = association.klass.connection.pool.db_config.database
+      resource_database = resource.connection.pool.db_config.database
 
       target_model_database != resource_database
     end

--- a/spec/services/forest_liana/resources_getter_spec.rb
+++ b/spec/services/forest_liana/resources_getter_spec.rb
@@ -83,26 +83,6 @@ module ForestLiana
       let(:resource) { Product }
       let(:fields) { { resource.name => 'id,name,manufacturer', 'manufacturer' => 'name' } }
 
-      shared_context 'resource current_database' do
-        before do
-          connection = resource.connection
-
-          def connection.current_database
-            'db/test.sqlite3'
-          end
-        end
-
-        after do
-          resource.connection.singleton_class.remove_method(:current_database)
-        end
-      end
-
-      shared_examples 'left outer join' do
-        it 'should perform a left outer join with the association' do
-          expect(getter.perform.to_sql).to match(/LEFT OUTER JOIN "manufacturers"/)
-        end
-      end
-
       shared_examples 'records' do
         it 'should get only the expected records' do
           getter.perform
@@ -117,40 +97,38 @@ module ForestLiana
         end
       end
 
-      context 'when the connections do not support current_database' do
-        include_examples 'left outer join'
+      context 'when the included association is in the same database' do
+        it 'performs a left outer join with the association' do
+          expect(getter.perform.to_sql).to match(/LEFT OUTER JOIN "manufacturers"/)
+        end
+
         include_examples 'records'
       end
 
-      context 'when the included association uses a different database connection' do
+      context 'when the included association is in a different database' do
         let(:fields) { { resource.name => 'id,name,driver', 'driver' => 'firstname' } }
-
-        before do
-          association_connection = resource.reflect_on_association(:driver).klass.connection
-
-          def association_connection.current_database
-            'db/different_test.sqlite3'
-          end
-        end
-
-        after do
-          resource.reflect_on_association(:driver).klass.connection.singleton_class.remove_method(:current_database)
-        end
-
-        include_context 'resource current_database'
-
-        include_examples 'records'
 
         it 'does not perform a left outer join with the association' do
           expect(getter.perform.to_sql).not_to match(/LEFT OUTER JOIN "drivers"/)
         end
+
+        include_examples 'records'
       end
 
-      context 'when the included association uses the same database connection' do
-        include_context 'resource current_database'
+      it 'resolves the database without issuing a SQL query' do
+        getter
 
-        include_examples 'left outer join'
-        include_examples 'records'
+        queries = []
+        subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+          queries << payload[:sql] unless payload[:name] == 'SCHEMA' || payload[:cached]
+        end
+        begin
+          getter.send(:separate_database?, Product, Product.reflect_on_association(:manufacturer))
+        ensure
+          ActiveSupport::Notifications.unsubscribe(subscriber)
+        end
+
+        expect(queries).to be_empty
       end
     end
 


### PR DESCRIPTION
## What

`BaseGetter#separate_database?` decides whether an association can be eager-loaded via a JOIN (same database) or must be preloaded separately (cross-database). It currently calls `connection.current_database` — a `SELECT current_database()` round-trip — twice per association (resource + association connection), on every request.

The database a connection points to is fixed at boot, so this reads it from the in-memory pool config instead:

```ruby
association.klass.connection.pool.db_config.database
resource.connection.pool.db_config.database
```

On apps with many collections across multiple databases, this removes a large share of read-replica queries.

## Why it's safe

- `connection.pool.db_config` is the same source `SchemaUtils#disable_filter_and_sort_if_cross_db!` already uses for cross-database detection.
- It keeps going through `.connection`, so it stays correct whether `resource` is a class (`ResourcesGetter`), a record instance, or a `CollectionProxy` (`HasManyGetter`). Reading `db_config` off the class-only `connection_db_config` would break the `HasManyGetter` path.
- The `respond_to?(:current_database)` guard is dropped — every adapter has `pool.db_config`. Bonus: two different SQLite databases are now correctly detected as separate (previously both returned `nil`, so they were treated as the same).

## Tests

Reworked the specs to use the dummy app's real multi-database setup (`Product` on `test`, `Driver` on `user`) instead of stubbing `current_database`, plus a test asserting `separate_database?` issues no SQL.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Avoid SQL queries in `separate_database?` by using `db_config` instead of `current_database`
> - Replaces `connection.current_database` with `connection.pool.db_config.database` in [`separate_database?`](https://github.com/ForestAdmin/forest-rails/pull/782/files#diff-b8f760393646995fca05cc29342760c53c6e7bb3a6544cedc7d351b2b8ebf315) to determine whether an association lives in a different database.
> - This avoids issuing a SQL query per association when checking database separation, and also handles cases where `current_database` is undefined.
> - Test helpers that monkey-patched `current_database` are removed and replaced with a spec that asserts no SQL queries are triggered by `separate_database?`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72ad471.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->