### PR TITLE
fix: serialize Array/Hash context variables as JSON instead of Ruby #to_s

### DIFF
--- a/app/services/forest_liana/utils/context_variables_injector.rb
+++ b/app/services/forest_liana/utils/context_variables_injector.rb
@@ -13,7 +13,7 @@ module ForestLiana
                           "Available context variables: #{available_keys}. "
             raise error_message
           end
-          value.to_s
+          value.is_a?(Array) || value.is_a?(Hash) ? value.to_json : value.to_s
         end
       end
 

--- a/spec/services/forest_liana/utils/context_variables_injector_spec.rb
+++ b/spec/services/forest_liana/utils/context_variables_injector_spec.rb
@@ -88,6 +88,7 @@ module ForestLiana
             { key: 'permissionLevel', expected_value: user['permissionLevel'] },
             { key: 'roleId', expected_value: user['roleId'] },
             { key: 'tags.planet', expected_value: user['tags'][0]['value'] },
+            { key: 'tags', expected_value: user['tags'].to_json },
             { key: 'team.id', expected_value: team['id'] },
             { key: 'team.name', expected_value: team['name'] }
           ].each do |value|


### PR DESCRIPTION
## Problem

When a segment query uses `{{currentUser.tags}}`, `ContextVariables#get_value` returns the raw Ruby `Array<Hash>`. The injector then calls `#to_s` on it, which produces Ruby's hash-rocket syntax:

```
[{"key"=>"planet", "value"=>"Death Star"}]
```

PostgreSQL rejects this with `PG::InvalidTextRepresentation` whenever the value is compared against a `json` or `jsonb` column:

```
ERROR:  invalid input syntax for type json
DETAIL:  Token "=" is invalid.
CONTEXT:  JSON data, line 1: [{"key" =...
```

Note: `{{currentUser.tags.planet}}` (a specific tag value via `USER_VALUE_TAG_PREFIX`) is **not** affected — it goes through a different branch and returns a scalar. Only `{{currentUser.tags}}` (the whole array) hits this path.

## Fix

Replace `value.to_s` with `value.to_json` for `Array` and `Hash` values so the substituted string is always valid JSON that database engines can parse.

## Test

Added `{ key: 'tags', expected_value: user['tags'].to_json }` to the existing currentUser variable test table, which was the only missing case and would have caught this regression.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serialize Array/Hash context variables as JSON in `ContextVariablesInjector.inject_context_in_value`
> Previously, Array and Hash context variable values were serialized using Ruby's `to_s`, producing unreadable output (e.g. `["a", "b"]` vs `["a", "b"]`). Now, [context_variables_injector.rb](https://github.com/ForestAdmin/forest-rails/pull/783/files#diff-5f9aa63da0549499862dc253eab6d4bbb5ff489e041c52ce7b25d41dce8a2774) checks the resolved value type and calls `to_json` for Arrays and Hashes, falling back to `to_s` for all other types.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 059c631.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->