### PR TITLE
fix: translate null equality/inequality filters to IS [NOT] NULL

### DIFF
--- a/app/services/forest_liana/filters_parser.rb
+++ b/app/services/forest_liana/filters_parser.rb
@@ -83,6 +83,10 @@ module ForestLiana
       value = condition['value']
       field_name = condition['field']
 
+      # NOTICE: captured before the enum mapping below, which turns an unknown
+      #         enum value into nil and would otherwise look like a null filter.
+      null_value = value.nil?
+
       if @operator_date_parser.is_date_operator?(operator)
         field_schema = SchemaUtils.find_column_schema_by_name(ForestLiana.name_for(@resource), field_name)
         condition = @operator_date_parser.get_date_filter(operator, value, field_schema)
@@ -99,6 +103,14 @@ module ForestLiana
 
       case_insensitive = operator == 'i_contains'
       parsed_field = parse_field_name(field_name, case_insensitive)
+
+      # NOTICE: the UI sends a null equality filter as a JSON null; `= NULL` and
+      #         `!= NULL` never match anything in SQL.
+      if null_value
+        return "#{parsed_field} IS NULL" if operator == 'equal'
+        return "#{parsed_field} IS NOT NULL" if operator == 'not_equal'
+      end
+
       parsed_operator = parse_operator(operator)
       parsed_value = parse_value(operator, value)
       field_and_operator = "#{parsed_field} #{parsed_operator}"

--- a/spec/services/forest_liana/filters_parser_spec.rb
+++ b/spec/services/forest_liana/filters_parser_spec.rb
@@ -45,6 +45,29 @@ module ForestLiana
             it { expect(parsed_filters.count).to eq 1 }
           end
 
+          context 'equal on a null value (JSON null from the UI)' do
+            before do
+              Tree.create!(name: nil, age: 42, island: Island.first)
+              Tree.create!(name: 'null', age: 43, island: Island.first)
+            end
+
+            let(:filters) { { 'field' => 'name', 'operator' => 'equal', 'value' => nil } }
+
+            it 'matches rows where the column IS NULL, not the literal string "null"' do
+              expect(parsed_filters.pluck(:name)).to eq([nil])
+            end
+          end
+
+          context 'not_equal on a null value (JSON null from the UI)' do
+            before { Tree.create!(name: nil, age: 42, island: Island.first) }
+
+            let(:filters) { { 'field' => 'name', 'operator' => 'not_equal', 'value' => nil } }
+
+            it 'matches rows where the column IS NOT NULL' do
+              expect(parsed_filters.pluck(:name)).to match_array(['Tree n1', 'Tree n2', 'Tree n3'])
+            end
+          end
+
           context 'greater_than' do
             let(:filters) { { 'field' => 'age', 'operator' => 'greater_than', 'value' => 2 } }
             it { expect(parsed_filters.count).to eq 2 }
@@ -104,6 +127,14 @@ module ForestLiana
 
           context 'equal' do
           let(:filters) { { 'field' => 'cutter:title', 'operator' => 'equal', 'value' => 'king' } }
+            it { expect(parsed_filters.count).to eq 0 }
+          end
+
+          context 'equal on an unknown enum value' do
+            # The enum mapping nils an unknown value; the null-filter guard is
+            # keyed on the pre-mapping value so it must NOT become `IS NULL`
+            # (that would wrongly match rows whose joined cutter is absent).
+            let(:filters) { { 'field' => 'cutter:title', 'operator' => 'equal', 'value' => 'not_a_title' } }
             it { expect(parsed_filters.count).to eq 0 }
           end
 


### PR DESCRIPTION
## Problem

When a user sets an equality filter to null, the Forest web app sends it as a
**JSON null** — e.g. an unresolved `{{currentUser.tags.…}}` template — which
reaches Ruby as `nil`. `FiltersParser` then builds `field = NULL` /
`field != NULL`, and neither ever matches anything in SQL, so the filter
silently returns zero rows.

(An exact-text search for the literal string `"null"` is intentionally left
alone, so a search for a row whose value is the text `"null"` keeps working.)

## Fix

Key the guard on `value.nil?`, captured **before** the enum mapping (which nils
unknown enum values and would otherwise look like a null filter), and cover both
operators:

```rb
null_value = value.nil?

# ... later, right after parsed_field ...
if null_value
  return "#{parsed_field} IS NULL" if operator == 'equal'
  return "#{parsed_field} IS NOT NULL" if operator == 'not_equal'
end
```

## Test

In `spec/services/forest_liana/filters_parser_spec.rb`:
- `equal` on a JSON null asserts `pluck(:name)` matches the NULL row and leaves a
  seeded `Tree.create!(name: 'null')` row unmatched (pins string-vs-null).
- `not_equal` on a JSON null matches the non-null rows (`IS NOT NULL`).
- a regression pinning the capture-before-enum ordering (`cutter:title equal
  "<unknown enum>"` stays `= NULL` → 0 rows).

95 examples / 0 failures; the two null specs go red when only the source file is
reverted. Full suite matches `main`.

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made — the guard emits a fixed
  `IS [NOT] NULL` SQL fragment (no interpolation of user input).
