### PR TITLE
fix: skip LIKE scans for malformed UUID searches

### DIFF
--- a/app/services/forest_liana/search_query_builder.rb
+++ b/app/services/forest_liana/search_query_builder.rb
@@ -85,7 +85,7 @@ module ForestLiana
             !@resource.defined_enums[column.name][@search.downcase].nil?
             conditions << "#{column_name} =
               #{@resource.defined_enums[column.name][@search.downcase]}"
-          elsif !(column.respond_to?(:array) && column.array) && text_type?(column.type)
+          elsif !(column.respond_to?(:array) && column.array) && text_type?(column.type) && !malformed_uuid_search?
             conditions << "LOWER(#{column_name}) LIKE :search_value_for_string"
           end
         end
@@ -114,7 +114,7 @@ module ForestLiana
               resource = @resource.reflect_on_association(association.to_sym)
               unless (SchemaUtils.polymorphic?(resource))
                 resource.klass.columns.each do |column|
-                  if !(column.respond_to?(:array) && column.array) && text_type?(column.type)
+                  if !(column.respond_to?(:array) && column.array) && text_type?(column.type) && !malformed_uuid_search?
                     if @collection.search_fields.nil? || (association_search &&
                       association_search.include?(column.name))
                       conditions << association_search_condition(resource.table_name,
@@ -138,7 +138,7 @@ module ForestLiana
               unless association_search.empty?
                 resource = @resource.reflect_on_association(association.to_sym)
                 resource.klass.columns.each do |column|
-                  if !(column.respond_to?(:array) && column.array) && text_type?(column.type)
+                  if !(column.respond_to?(:array) && column.array) && text_type?(column.type) && !malformed_uuid_search?
                     if association_search.include?(column.name)
                       conditions << association_search_condition(resource.table_name,
                         column.name)
@@ -150,11 +150,18 @@ module ForestLiana
           end
         end
 
-        @records = @resource.where(
-          conditions.join(' OR '),
-          search_value_for_string: "%#{@search.downcase}%",
-          search_value_for_uuid: @search.to_s
-        ) unless conditions.empty?
+        if conditions.empty?
+          # NOTICE: a malformed-UUID search suppresses the only conditions it could
+          #         have produced (text LIKE scans); match nothing rather than fall
+          #         through to an unfiltered query that returns the whole table.
+          @records = @resource.none if malformed_uuid_search?
+        else
+          @records = @resource.where(
+            conditions.join(' OR '),
+            search_value_for_string: "%#{@search.downcase}%",
+            search_value_for_uuid: @search.to_s
+          )
+        end
       end
 
       @records
@@ -222,6 +229,18 @@ module ForestLiana
 
     def text_type?(type_sym)
       [:string, :text, :citext].include? type_sym
+    end
+
+    # NOTICE: A search that is UUID-shaped but fails the strict REGEX_UUID (a
+    #         truncated or mistyped UUID) can never match a real UUID column and,
+    #         on text columns, only triggers `LOWER(col) LIKE '%…%'` sequential
+    #         scans that can hit the statement timeout. Valid UUIDs are excluded
+    #         so they keep matching UUIDs stored in varchar/text columns.
+    def malformed_uuid_search?
+      return false unless @search.is_a?(String)
+
+      @search.match?(/\A[0-9a-f]+-[0-9a-f]+-[0-9a-f]+-[0-9a-f]+-[0-9a-f]+\z/i) &&
+        !REGEX_UUID.match?(@search)
     end
   end
 end

--- a/spec/services/forest_liana/search_query_builder_spec.rb
+++ b/spec/services/forest_liana/search_query_builder_spec.rb
@@ -16,6 +16,50 @@ module ForestLiana
     end
 
     describe '#perform' do
+      context 'when the search is a malformed UUID' do
+        # UUID-shaped but fails the strict REGEX_UUID (mistyped/truncated group).
+        # Starts with a letter so #to_i is 0 and adds no integer-`id` condition,
+        # leaving the text LIKE scans as the only possible matches.
+        let(:params) { { search: 'abcdef12-3456-4ae-ad4f-5662757713a2', searchExtended: '0' } }
+
+        before do
+          Tree.create!(name: 'Oak')
+          Tree.create!(name: 'Elm')
+        end
+
+        after { Tree.destroy_all }
+
+        it 'matches nothing instead of returning the unfiltered table' do
+          expect(builder.perform(Tree.all).count).to eq(0)
+        end
+      end
+
+      context 'when searchExtended is on and the search is a malformed UUID' do
+        # HashWithIndifferentAccess: the code reads @params['searchExtended'] (string).
+        let(:params) do
+          ActiveSupport::HashWithIndifferentAccess.new(
+            search: 'abcdef12-3456-4ae-ad4f-5662757713a2', searchExtended: '1'
+          )
+        end
+        let(:builder) { described_class.new(params, [:owner], collection, user) }
+
+        before { Tree.create!(name: 'Oak') }
+
+        after { Tree.destroy_all }
+
+        it 'does not build LIKE scans on associated text columns either' do
+          expect(builder.perform(Tree.all).to_sql).not_to match(/LIKE/i)
+        end
+      end
+
+      context 'when the search is a valid UUID' do
+        let(:params) { { search: '75fbcb43-f6f8-4cd1-861f-09a61fd1ddad', searchExtended: '0' } }
+
+        it 'still builds a LIKE scan on text columns (UUIDs stored as text)' do
+          expect(builder.perform(Tree.all).to_sql).to match(/LIKE/i)
+        end
+      end
+
       context 'when a column is an array uuid type' do
         let(:array_uuid_column) do
           double('Column', name: 'attachment_ids', type: :uuid, array: true).tap do |col|


### PR DESCRIPTION
## Problem

When a search term is UUID-shaped but fails the strict `REGEX_UUID` (for example
a truncated or mistyped UUID such as `877a7915-2bc3-4ae-ad4f-5662757713a2`),
`SearchQueryBuilder#search_param` still falls through to
`LOWER(col) LIKE '%…%'` conditions on every text column. On large tables these
force sequential scans across all text columns and can hit the database
statement timeout.

## Fix

Skip the `LIKE` conditions when the search looks UUID-like:

```rb
elsif !(column.respond_to?(:array) && column.array) && text_type?(column.type) && !uuid_like_search?
  conditions << "LOWER(#{column_name}) LIKE :search_value_for_string"
end

# ...

def uuid_like_search?
  @search.match?(/\A[0-9a-f]+-[0-9a-f]+-[0-9a-f]+-[0-9a-f]+-[0-9a-f]+\z/i)
end
```

Exact UUID matches on `id`/`uuid` columns are unaffected (they use the strict
`REGEX_UUID` path).

## Test

Added a spec in `spec/services/forest_liana/search_query_builder_spec.rb`: a
malformed-UUID search produces no `LIKE` condition. Verified the generated SQL
contains `LIKE` before the change and does not after. Full suite green.

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made — reduces load/DoS surface
  from expensive full-table scans; the regex only gates which conditions are built.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip LIKE scans in `SearchQueryBuilder` for malformed UUID search strings
> - Adds a `malformed_uuid_search?` predicate in [search_query_builder.rb](https://github.com/ForestAdmin/forest-rails/pull/786/files#diff-fa135f02c0c5311220e1b811b2332b4c7e337954342efc5a94503d847d836841) that returns true when the search string loosely matches a UUID pattern but fails the strict `REGEX_UUID` check.
> - Suppresses `LOWER(col) LIKE '%...%'` conditions on text columns when the search is a malformed UUID, preventing irrelevant full-table LIKE scans across base and associated columns.
> - Returns `@resource.none` when no conditions are built and the search is a malformed UUID, avoiding an unfiltered result set.
> - Behavioral Change: malformed UUID searches now return zero records instead of all records when no other predicates apply.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dde2a07.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->