### PR TITLE
fix: handle nil datetime group key in pie chart aggregation

### DIFF
--- a/app/services/forest_liana/pie_stat_getter.rb
+++ b/app/services/forest_liana/pie_stat_getter.rb
@@ -33,7 +33,9 @@ module ForestLiana
               key = @resource.defined_enums[@params[:groupByFieldName]].invert[key]
             elsif @resource.columns_hash[@params[:groupByFieldName]] &&
               @resource.columns_hash[@params[:groupByFieldName]].type == :datetime
-              key = (key + timezone_offset.hours).strftime('%d/%m/%Y %T')
+              # NOTICE: A nil datetime group key would raise NoMethodError on
+              #         `nil + timezone_offset.hours`; label it explicitly.
+              key = key.present? ? (key + timezone_offset.hours).strftime('%d/%m/%Y %T') : 'No value'
             end
 
             { key: key, value: value }

--- a/spec/services/forest_liana/pie_stat_getter_spec.rb
+++ b/spec/services/forest_liana/pie_stat_getter_spec.rb
@@ -44,6 +44,33 @@ module ForestLiana
       end
     end
 
+    describe 'grouping by a nullable datetime field with a null value' do
+      let(:scopes) { {'scopes' => {}, 'team' => {'id' => '1', 'name' => 'Operations'}} }
+      let(:model) { Tree }
+      let(:collection) { 'trees' }
+      let(:params) {
+        {
+          type: 'Pie',
+          sourceCollectionName: collection,
+          timezone: 'Europe/Paris',
+          aggregator: 'Count',
+          groupByFieldName: 'created_at'
+        }
+      }
+
+      subject { PieStatGetter.new(model, params, user) }
+
+      before do
+        tree = Tree.create!(name: 'No date tree', age: 1)
+        tree.update_columns(created_at: nil)
+      end
+
+      it 'labels the null bucket "No value" instead of raising on nil + offset' do
+        expect { subject.perform }.not_to raise_error
+        expect(subject.record.value.map { |entry| entry[:key] }).to include('No value')
+      end
+    end
+
     describe 'with valid aggregate function' do
       let(:model) { Tree }
       let(:collection) { 'trees' }


### PR DESCRIPTION
## Problem

When a pie chart groups by a nullable `datetime` column and a bucket key is
`nil`, `PieStatGetter#perform` evaluates `(key + timezone_offset.hours)` on
`nil`, raising `NoMethodError: undefined method '+' for nil` and failing the
whole chart request.

## Fix

Guard the nil key and label it explicitly:

```rb
key = key.present? ? (key + timezone_offset.hours).strftime('%d/%m/%Y %T') : 'No value'
```

## Test

Added a spec in `spec/services/forest_liana/pie_stat_getter_spec.rb`: grouping by
a datetime column that has a null value no longer raises and produces a
`"No value"` bucket. Verified red (NoMethodError) before / green after. Full
suite green.

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made — none.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix nil datetime group key crash in pie chart aggregation
> When grouping a pie chart by a datetime field, records with a `nil` value caused an error because the code unconditionally applied a timezone offset and `strftime` to the key. A presence check is added in [`pie_stat_getter.rb`](https://github.com/ForestAdmin/forest-rails/pull/787/files#diff-5695b039b5eee6b66e323be064dd6507fbb3f8a99dde348196662210cf84699b) so that `nil` keys are returned as `'No value'` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8c2538.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->