### PR TITLE
fix: return 404 not 500 when counting an unknown relationship

### DIFF
--- a/app/controllers/forest_liana/associations_controller.rb
+++ b/app/controllers/forest_liana/associations_controller.rb
@@ -27,6 +27,11 @@ module ForestLiana
     def count
       find_resource
       find_association
+      # NOTICE: find_association renders a 404 (without halting) when the
+      #         association name does not resolve; stop here instead of falling
+      #         through and dereferencing a nil @association, which surfaced as
+      #         a double-render / 500 rather than the intended 404.
+      return if performed?
       begin
         getter = HasManyGetter.new(@resource, @association, params, forest_user)
         getter.count

--- a/spec/requests/count_spec.rb
+++ b/spec/requests/count_spec.rb
@@ -74,6 +74,20 @@ describe 'Requesting Owner', :type => :request  do
     end
   end
 
+  describe 'count on an unknown relationship' do
+    params = {
+      fields: { 'Tree' => 'id,name,owner' },
+      page: { 'number' => '1', 'size' => '10' },
+      searchExtended: '0',
+      timezone: 'Europe/Paris'
+    }
+
+    it 'should respond 404 instead of 500' do
+      get '/forest/Owner/5/relationships/unknown_things/count', params: params, headers: headers
+      expect(response.status).to eq(404)
+    end
+  end
+
   describe 'deactivate_count_response' do
     params = {
       fields: { 'Owner' => 'id,name' },


### PR DESCRIPTION
## Problem

`AssociationsController#count` calls `find_association` manually (it is a
`before_action` for every *other* action, via `except: :count`). When the
association name does not resolve, `find_association` renders a `404` but does
**not** halt, so `count` continues, builds a `HasManyGetter` with a `nil`
association and dereferences it. The result is a double-render / `500` instead
of the intended `404`.

This is reachable from the Forest UI whenever a stale/cached client schema
requests a count on an association name that no longer resolves on the model.

## Fix

Bail out once the response has already been rendered:

```rb
def count
  find_resource
  find_association
  return if performed?
  begin
    # ...
```

## Test

Added a request spec in `spec/requests/count_spec.rb`:
`GET /forest/Owner/5/relationships/unknown_things/count` now responds `404`
instead of `500`. Verified red (500) before / green after. Full suite green.

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made — turns an unhandled 500
  (with stack-trace reporting) into a clean 404 for unresolvable associations.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `AssociationsController#count` to return 404 instead of 500 for unknown relationships
> In the `count` action, `find_association` can render a 404 without halting execution, causing subsequent code to dereference a nil `@association` and raise a 500. A `return if performed?` guard is added after `find_association` to exit early when a response has already been rendered.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b872fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->