### PR TITLE
fix(has-many-getter): stop dropping records when a has_one is one-to-many in the data

### DIFF
--- a/app/services/forest_liana/has_many_getter.rb
+++ b/app/services/forest_liana/has_many_getter.rb
@@ -121,5 +121,95 @@ module ForestLiana
     def pagination?
       @params[:page] && @params[:page][:number]
     end
+
+    # Overrides BaseGetter#optimize_record_loading for the has-many relationship path.
+    #
+    # BaseGetter eager_loads every belongs_to/has_one/HABTM association of the target
+    # model in a single LEFT OUTER JOIN, and #records then applies LIMIT/OFFSET on top of
+    # it. When an association is declared `has_one` but is one-to-many in the data, Rails
+    # keeps it singular and does NOT switch to the limited-ids strategy, so LIMIT is applied
+    # directly to the row-multiplied JOIN output: a page collapses to fewer DISTINCT records
+    # than requested and records past the window are silently dropped (the count stays right
+    # because #count uses COUNT(DISTINCT id)).
+    #
+    # These associations are eager-loaded only to serialize the related-list columns, not
+    # for the query's WHERE/ORDER. So keep eager-loaded only the associations the current
+    # request sorts or filters BY (their joins must resolve), and preload the remaining
+    # display-only associations (separate queries, no row multiplication). LIMIT then applies
+    # to the un-multiplied base rows and returns the correct DISTINCT records.
+    def optimize_record_loading(resource, records, force_preload = true)
+      polymorphic, preload_loads = analyze_associations(resource)
+      display_includes = @includes.uniq - preload_loads - polymorphic - @optional_includes
+
+      keep_eager = display_includes & associations_referenced_by_sort_and_filters
+      move_to_preload = display_includes - keep_eager
+
+      result = records.eager_load(keep_eager)
+
+      # NOTICE: Rails 6 cannot mix `eager_load` and `preload` in the same scope (see #567),
+      # so the display-only associations are preloaded on Rails 7+ and lazy-loaded on Rails 6.
+      # Either way LIMIT is no longer applied to a row-multiplied JOIN.
+      if Rails::VERSION::MAJOR >= 7 && force_preload
+        result = result.preload(move_to_preload + preload_loads)
+      end
+
+      result
+    end
+
+    # Association names (symbols) referenced by the request's sort and filters. Their joins
+    # must stay eager-loaded so SearchQueryBuilder#sort_query (ORDER BY a relation column)
+    # and relation filters resolve their columns.
+    def associations_referenced_by_sort_and_filters
+      (associations_referenced_by_sort + associations_referenced_by_filters).uniq
+    end
+
+    # @params[:sort] is a comma-separated string; a leading '-' means descending and a '.'
+    # references a relation (the part before the dot). e.g. '-owner.name' => :owner
+    def associations_referenced_by_sort
+      sort = @params[:sort]
+      return [] if sort.nil? || sort.to_s.empty?
+
+      sort.to_s.split(',').map do |field|
+        field = field.strip.sub(/\A-/, '')
+        field.include?('.') ? field.split('.').first.to_sym : nil
+      end.compact
+    end
+
+    # @params[:filters] is a JSON string or a condition tree (Hash). A leaf field references
+    # a relation with ':' (belongs_to style) or '.' (nested); aggregation nodes nest under
+    # 'conditions'. e.g. 'owner:name' => :owner
+    def associations_referenced_by_filters
+      filters = @params[:filters]
+      return [] if filters.nil? || (filters.respond_to?(:empty?) && filters.empty?)
+
+      tree = filters.is_a?(String) ? parse_filters_json(filters) : filters
+      tree = tree.to_unsafe_h if tree.respond_to?(:to_unsafe_h)
+      extract_filter_associations(tree)
+    end
+
+    def parse_filters_json(raw)
+      JSON.parse(raw)
+    rescue JSON::ParserError
+      nil
+    end
+
+    def extract_filter_associations(node)
+      return [] unless node.is_a?(Hash)
+
+      conditions = node['conditions'] || node[:conditions]
+      return Array(conditions).flat_map { |child| extract_filter_associations(child) } if conditions
+
+      field = node['field'] || node[:field]
+      return [] if field.nil? || field.to_s.empty?
+
+      field = field.to_s
+      if field.include?(':')
+        [field.split(':').first.to_sym]
+      elsif field.include?('.')
+        [field.split('.').first.to_sym]
+      else
+        []
+      end
+    end
   end
 end

--- a/app/services/forest_liana/has_many_getter.rb
+++ b/app/services/forest_liana/has_many_getter.rb
@@ -134,33 +134,37 @@ module ForestLiana
     #
     # These associations are eager-loaded only to serialize the related-list columns, not
     # for the query's WHERE/ORDER. So keep eager-loaded only the associations the current
-    # request sorts or filters BY (their joins must resolve), and preload the remaining
-    # display-only associations (separate queries, no row multiplication). LIMIT then applies
-    # to the un-multiplied base rows and returns the correct DISTINCT records.
+    # request needs a JOIN for (sort BY a relation column, or SearchQueryBuilder's extended
+    # search, which builds its OR conditions against the already-joined tables), and preload
+    # the remaining display-only associations (separate queries, no row multiplication).
+    # Filters on a relation column are unaffected: FiltersParser#apply_filters already calls
+    # `eager_load` for those associations itself, earlier in the pipeline (see #prepare_query),
+    # and that join composes fine with the one added here. LIMIT then applies to the
+    # un-multiplied base rows and returns the correct DISTINCT records.
     def optimize_record_loading(resource, records, force_preload = true)
       polymorphic, preload_loads = analyze_associations(resource)
       display_includes = @includes.uniq - preload_loads - polymorphic - @optional_includes
 
-      keep_eager = display_includes & associations_referenced_by_sort_and_filters
+      keep_eager = display_includes & associations_to_keep_eager
       move_to_preload = display_includes - keep_eager
 
       result = records.eager_load(keep_eager)
+      return result unless force_preload
 
-      # NOTICE: Rails 6 cannot mix `eager_load` and `preload` in the same scope (see #567),
-      # so the display-only associations are preloaded on Rails 7+ and lazy-loaded on Rails 6.
-      # Either way LIMIT is no longer applied to a row-multiplied JOIN.
-      if Rails::VERSION::MAJOR >= 7 && force_preload
-        result = result.preload(move_to_preload + preload_loads)
-      end
+      # NOTICE: mixing `eager_load` and `preload` in the same scope works fine on Rails 6 as
+      # long as the preloaded association isn't instance-dependent (see #567) — analyze_associations
+      # already routed those (and cross-DB ones) into `preload_loads`, so `move_to_preload` is
+      # always safe to preload; only `preload_loads` needs the Rails 7+ gate.
+      result = result.preload(move_to_preload)
+      result = result.preload(preload_loads) if Rails::VERSION::MAJOR >= 7
 
       result
     end
 
-    # Association names (symbols) referenced by the request's sort and filters. Their joins
-    # must stay eager-loaded so SearchQueryBuilder#sort_query (ORDER BY a relation column)
-    # and relation filters resolve their columns.
-    def associations_referenced_by_sort_and_filters
-      (associations_referenced_by_sort + associations_referenced_by_filters).uniq
+    # Association names (symbols) whose JOIN the current request actually needs, so they must
+    # stay in `eager_load` rather than move to `preload`.
+    def associations_to_keep_eager
+      (associations_referenced_by_sort + associations_referenced_by_extended_search).uniq
     end
 
     # @params[:sort] is a comma-separated string; a leading '-' means descending and a '.'
@@ -175,40 +179,18 @@ module ForestLiana
       end.compact
     end
 
-    # @params[:filters] is a JSON string or a condition tree (Hash). A leaf field references
-    # a relation with ':' (belongs_to style) or '.' (nested); aggregation nodes nest under
-    # 'conditions'. e.g. 'owner:name' => :owner
-    def associations_referenced_by_filters
-      filters = @params[:filters]
-      return [] if filters.nil? || (filters.respond_to?(:empty?) && filters.empty?)
+    # SearchQueryBuilder#search_param, when `searchExtended=1`, adds `OR` conditions against
+    # every included one-association's columns and relies on its table already being joined.
+    # Mirror the associations it can reach so their JOIN stays eager instead of moving to
+    # preload (which never joins, on any Rails version).
+    def associations_referenced_by_extended_search
+      return [] unless @params[:search].present? && @params['searchExtended'].to_i == 1
 
-      tree = filters.is_a?(String) ? parse_filters_json(filters) : filters
-      tree = tree.to_unsafe_h if tree.respond_to?(:to_unsafe_h)
-      extract_filter_associations(tree)
-    end
-
-    def parse_filters_json(raw)
-      JSON.parse(raw)
-    rescue JSON::ParserError
-      nil
-    end
-
-    def extract_filter_associations(node)
-      return [] unless node.is_a?(Hash)
-
-      conditions = node['conditions'] || node[:conditions]
-      return Array(conditions).flat_map { |child| extract_filter_associations(child) } if conditions
-
-      field = node['field'] || node[:field]
-      return [] if field.nil? || field.to_s.empty?
-
-      field = field.to_s
-      if field.include?(':')
-        [field.split(':').first.to_sym]
-      elsif field.include?('.')
-        [field.split('.').first.to_sym]
-      else
-        []
+      target_model = model_association
+      includes_symbols = @includes.map(&:to_sym)
+      QueryHelper.get_one_association_names_symbol(target_model).select do |association_name|
+        includes_symbols.include?(association_name) &&
+          !SchemaUtils.polymorphic?(target_model.reflect_on_association(association_name))
       end
     end
   end

--- a/spec/services/forest_liana/has_many_getter_pagination_spec.rb
+++ b/spec/services/forest_liana/has_many_getter_pagination_spec.rb
@@ -1,0 +1,137 @@
+module ForestLiana
+  # Regression test for related-list pagination dropping records.
+  # See HasManyGetter#optimize_record_loading: a `has_one` association that actually
+  # resolves to MANY rows makes the eager_load JOIN multiply rows, so LIMIT used to
+  # collapse a page to fewer DISTINCT records than requested and silently drop the rest.
+  describe HasManyGetter, 'pagination with a has_one that is one-to-many in the data' do
+    let(:rendering_id) { 13 }
+    let(:user) { { 'id' => '1', 'rendering_id' => rendering_id } }
+    let(:scopes) { { 'scopes' => {}, 'team' => { 'id' => '1', 'name' => 'Operations' } } }
+    let(:association) { Island.reflect_on_association(:trees) }
+
+    let(:island) { Island.create!(name: 'sicily') }
+    let(:page_size) { 2 }
+    let(:params) do
+      {
+        id: island.id,
+        association_name: 'trees',
+        sort: 'id',
+        page: { size: page_size, number: 1 },
+        timezone: 'America/Nome'
+      }
+    end
+
+    subject { described_class.new(Island, association, params, user) }
+
+    before(:each) do
+      # A has_one declared on the target model that actually returns MANY rows: every tree
+      # sharing the island. Eager-loading it turns one tree into N joined rows.
+      Tree.class_eval do
+        has_one :island_neighbour, class_name: 'Tree', foreign_key: 'island_id', primary_key: 'island_id'
+      end
+
+      @alice = User.create!(name: 'Alice')
+      @bob = User.create!(name: 'Bob')
+      @trees = [
+        Tree.create!(name: 'cedar', island: island, owner: @alice),
+        Tree.create!(name: 'olive', island: island, owner: @bob),
+        Tree.create!(name: 'pine',  island: island, owner: @alice),
+        Tree.create!(name: 'fig',   island: island, owner: @bob)
+      ]
+
+      ForestLiana::ScopeManager.invalidate_scope_cache(rendering_id)
+      allow(ForestLiana::ScopeManager).to receive(:fetch_scopes).and_return(scopes)
+    end
+
+    after(:each) do
+      Tree._reflections.delete('island_neighbour')
+      Tree.reflections.delete('island_neighbour')
+      %w[island_neighbour island_neighbour= build_island_neighbour
+         create_island_neighbour create_island_neighbour! reload_island_neighbour].each do |m|
+        Tree.undef_method(m) rescue nil
+      end
+      Tree.destroy_all
+      Island.destroy_all
+      User.destroy_all
+    end
+
+    it 'still lists the mis-declared has_one among the eager-load candidates' do
+      expect(subject.includes).to include(:island_neighbour)
+    end
+
+    it 'returns exactly page_size DISTINCT records, not collapsed by the JOIN' do
+      subject.perform
+      ids = subject.records.map(&:id)
+
+      expect(ids.size).to eq(page_size)
+      expect(ids.uniq.size).to eq(page_size)
+    end
+
+    it 'does not JOIN the one-to-many association for a base-column sort' do
+      subject.perform
+
+      expect(subject.records.to_sql.scan(/LEFT OUTER JOIN/i)).to be_empty
+    end
+
+    it 'walks every page yielding all records exactly once' do
+      seen = []
+      pages = (@trees.size.to_f / page_size).ceil
+      pages.times do |i|
+        getter = described_class.new(
+          Island, association, params.merge(page: { size: page_size, number: i + 1 }), user
+        )
+        getter.perform
+        seen.concat(getter.records.map(&:id))
+      end
+
+      expect(seen.sort).to eq(@trees.map(&:id).sort)
+      expect(seen.uniq.size).to eq(@trees.size)
+    end
+
+    it 'keeps the total count correct' do
+      subject.perform
+
+      expect(subject.count).to eq(@trees.size)
+    end
+
+    describe 'when sorting by a relation column' do
+      let(:params) do
+        {
+          id: island.id,
+          association_name: 'trees',
+          sort: 'owner.name',
+          page: { size: 15, number: 1 },
+          timezone: 'America/Nome'
+        }
+      end
+
+      it 'keeps the relation joined and returns all records ordered by it' do
+        subject.perform
+        names = subject.records.to_a.map { |tree| tree.owner.name }
+
+        expect(names.size).to eq(@trees.size)
+        expect(names).to eq(names.sort)
+      end
+    end
+
+    describe 'when filtering by a relation column' do
+      let(:params) do
+        {
+          id: island.id,
+          association_name: 'trees',
+          filters: { field: 'owner:name', operator: 'equal', value: 'Alice' }.to_json,
+          page: { size: 15, number: 1 },
+          timezone: 'America/Nome'
+        }
+      end
+
+      it 'keeps the relation joined and returns only the matching records' do
+        subject.perform
+        records = subject.records.to_a
+
+        expect(records.size).to eq(2)
+        expect(records.map { |tree| tree.owner.name }.uniq).to eq(['Alice'])
+      end
+    end
+  end
+end

--- a/spec/services/forest_liana/has_many_getter_pagination_spec.rb
+++ b/spec/services/forest_liana/has_many_getter_pagination_spec.rb
@@ -133,5 +133,30 @@ module ForestLiana
         expect(records.map { |tree| tree.owner.name }.uniq).to eq(['Alice'])
       end
     end
+
+    describe 'with extended search across a display-only association' do
+      # Regression for review comment on #790: SearchQueryBuilder#search_param, with
+      # searchExtended=1, emits `OR LOWER("users"."name") LIKE ...` for every included
+      # one-association and relies on that table already being joined. `owner` isn't
+      # referenced by sort or filters here, so it would have moved to `preload` (which
+      # never joins) and blown up the query with a missing FROM-clause entry.
+      let(:params) do
+        {
+          id: island.id,
+          association_name: 'trees',
+          search: 'alice',
+          'searchExtended' => '1',
+          page: { size: 15, number: 1 },
+          timezone: 'America/Nome'
+        }
+      end
+
+      it 'keeps the searched association joined and returns only the matching records' do
+        subject.perform
+        records = subject.records.to_a
+
+        expect(records.map(&:name)).to contain_exactly('cedar', 'pine')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

Forest Admin **has-many / related-list** endpoints can silently drop records and return short pages. A page requested with `page[size]=N` comes back with fewer than `N` **distinct** records, so the UI concludes it reached the last page and hides the remaining pages. The total-count badge stays correct, which masks the bug.

## Root cause

`BaseGetter#optimize_record_loading` eager-loads **every** `belongs_to` / `has_one` / `has_and_belongs_to_many` association of the target model into one big `LEFT OUTER JOIN`, and `HasManyGetter#records` then applies `.limit(size).offset(...)` on top of it.

When an association is declared `has_one` but is actually **one-to-many in the data**, Rails keeps it singular and does **not** switch to the limited-ids strategy — so `LIMIT` is applied directly to the row-multiplied JOIN output. A page of N joined rows collapses to only a handful of **distinct** records, and records past that window are dropped. `HasManyGetter#count` stays correct because it counts `DISTINCT` ids.

These associations are eager-loaded only to serialize the related-list columns — not for the query's `WHERE` / `ORDER`. The exceptions are: `SearchQueryBuilder#sort_query` needs the join when sorting BY a relation column (`"rel.field"`), and `FiltersParser` when filtering on a relation (`"rel:field"`, which already self-manages its own join).

## Fix

Override `optimize_record_loading` **in `HasManyGetter`** (the relationship path only — `ResourcesGetter` / index path is untouched) to:

- keep **eager-loaded** only the associations the current request sorts/filters by (parsed from `@params[:sort]` and `@params[:filters]`), so relation-column sort/filter still resolve their joins;
- **preload** the remaining display-only associations — separate queries, no row multiplication.

`LIMIT` then applies to the un-multiplied base rows and returns the correct number of distinct records; display associations are still loaded (via `preload`) for serialization.

The preload stays gated to Rails 7+ (matching #567 — Rails 6 cannot mix `eager_load` and `preload` in the same scope). On Rails 6 the display associations fall back to lazy loading and **pagination is still correct** (the multiplying join is gone either way).

## Tests

New `spec/services/forest_liana/has_many_getter_pagination_spec.rb` adds a target-model `has_one` that resolves to many rows and asserts:

1. a page of size N (< total) returns exactly N **distinct** records, no duplicates;
2. no multiplying JOIN in the paginated SQL for a base-column sort;
3. walking all pages yields every record exactly once;
4. the total count stays correct;
5. sorting BY a relation column still works (relation stays joined);
6. filtering BY a relation column still works (relation stays joined).

Full suite green locally (Ruby 3.3.6 / Rails 6.1): `465 examples, 0 failures`, including the existing `has_many_getter_spec` and `resources_getter_spec`.

## Impact

Affects **every** has-many related list whose target model has a data-wise one-to-many association mis-declared as `has_one` in its eager-load set.

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following Conventional Commits specification
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made — none; this only changes how associations are loaded (eager_load vs preload) for pagination, no change to scoping/authorization or the records returned.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `HasManyGetter` dropping records when `has_one` is one-to-many in data
> - Splits `@includes` into associations that stay eager-loaded (JOINed) versus preloaded, so JOIN row multiplication no longer collapses pagination pages and `LIMIT`/`OFFSET` apply to base rows
> - Keeps an association JOINed only when the request sorts or extended-searches on it; all other display includes move to separate `preload` calls
> - On Rails >= 7, instance-dependent and cross-DB preloads from `analyze_associations` are also preloaded; on older Rails they are not
> - Adds regression tests in [has_many_getter_pagination_spec.rb](https://github.com/ForestAdmin/forest-rails/pull/790/files#diff-5618d656122caa5b96b4a75e95395127f4cd3c601d05c3b90f1d71ee6b724449) covering mis-declared `has_one`, page sizes, distinct IDs, total count, and JOIN behavior for sort and extended search
> - Behavioral Change: `HasManyGetter.optimize_record_loading` now overrides `BaseGetter#optimize_record_loading`; associations no longer referenced in the SQL JOIN may load in separate queries, changing query count and shape
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b69b28.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->