### PR TITLE
fix(count): search the same columns for a count as for its list

### DIFF
--- a/app/services/forest_liana/base_getter.rb
+++ b/app/services/forest_liana/base_getter.rb
@@ -24,6 +24,14 @@ module ForestLiana
       @optional_includes = []
     end
 
+    # A search predicate can only name an association the eager load actually joins;
+    # analyze_associations drops the rest, leaving their table out of the FROM clause.
+    def searchable_includes(resource)
+      polymorphic, preload_loads = analyze_associations(resource)
+
+      (@includes - polymorphic - preload_loads).map(&:to_sym)
+    end
+
     def optimize_record_loading(resource, records, force_preload = true)
       polymorphic, preload_loads = analyze_associations(resource)
       result = records.eager_load(@includes.uniq - preload_loads - polymorphic - @optional_includes)

--- a/app/services/forest_liana/has_many_getter.rb
+++ b/app/services/forest_liana/has_many_getter.rb
@@ -14,7 +14,7 @@ module ForestLiana
       @field_names_requested = field_names_requested
       @collection = get_collection(@collection_name)
       compute_includes()
-      @search_query_builder = SearchQueryBuilder.new(@params, searchable_includes, @collection, forest_user)
+      @search_query_builder = SearchQueryBuilder.new(@params, searchable_includes(model_association), @collection, forest_user)
 
       prepare_query()
     end
@@ -64,14 +64,6 @@ module ForestLiana
     end
 
     private
-
-    # A search predicate can only name an association the eager load actually joins;
-    # analyze_associations drops the rest, leaving their table out of the FROM clause.
-    def searchable_includes
-      polymorphic, preload_loads = analyze_associations(model_association)
-
-      (@includes - polymorphic - preload_loads).map(&:to_sym)
-    end
 
     def compute_includes
       @optional_includes = []

--- a/app/services/forest_liana/has_many_getter.rb
+++ b/app/services/forest_liana/has_many_getter.rb
@@ -76,12 +76,18 @@ module ForestLiana
             inclusion = SchemaUtils.model_included?(association.klass)
           end
 
-          if @field_names_requested.any?
+          if @field_names_requested.any? && !search_extended?
             inclusion && @field_names_requested.include?(association.name)
           else
             inclusion
           end
         end.map(&:name)
+    end
+
+    # Extended search reaches the associated tables, so its footprint must not depend
+    # on the projection: a count carries none, and would otherwise search more than the list.
+    def search_extended?
+      @params['searchExtended'].to_i == 1
     end
 
     def field_names_requested

--- a/app/services/forest_liana/has_many_getter.rb
+++ b/app/services/forest_liana/has_many_getter.rb
@@ -14,8 +14,7 @@ module ForestLiana
       @field_names_requested = field_names_requested
       @collection = get_collection(@collection_name)
       compute_includes()
-      includes_symbols = @includes.map { |include| include.to_sym }
-      @search_query_builder = SearchQueryBuilder.new(@params, includes_symbols, @collection, forest_user)
+      @search_query_builder = SearchQueryBuilder.new(@params, searchable_includes, @collection, forest_user)
 
       prepare_query()
     end
@@ -58,7 +57,21 @@ module ForestLiana
       @records.limit(limit).offset(offset)
     end
 
+    def includes_for_serialization
+      return super if @field_names_requested.empty?
+
+      super & @field_names_requested.map(&:to_s)
+    end
+
     private
+
+    # A search predicate can only name an association the eager load actually joins;
+    # analyze_associations drops the rest, leaving their table out of the FROM clause.
+    def searchable_includes
+      polymorphic, preload_loads = analyze_associations(model_association)
+
+      (@includes - polymorphic - preload_loads).map(&:to_sym)
+    end
 
     def compute_includes
       @optional_includes = []

--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -6,7 +6,7 @@ module ForestLiana
       @resource = resource
       @params = params
       @user = forest_user
-      @count_needs_includes = false
+      @count_needs_includes = !@params[:search].nil?
       @collection_name = ForestLiana.name_for(@resource)
       @collection = get_collection(@collection_name)
       @fields_to_serialize = get_fields_to_serialize
@@ -176,8 +176,6 @@ module ForestLiana
           @count_needs_includes = true
         end
       end
-
-      @count_needs_includes = true if @params[:search]
 
       associations.uniq
     end

--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -13,7 +13,7 @@ module ForestLiana
       @field_names_requested = field_names_requested
       @segment = get_segment
       compute_includes
-      @search_query_builder = SearchQueryBuilder.new(@params, @includes, @collection, @user)
+      @search_query_builder = SearchQueryBuilder.new(@params, searchable_includes(@resource), @collection, @user)
 
       prepare_query
       @base_records_for_batch = @records

--- a/spec/requests/count_spec.rb
+++ b/spec/requests/count_spec.rb
@@ -130,3 +130,246 @@ describe 'Requesting Owner', :type => :request  do
     end
   end
 end
+
+describe 'Requesting Tree count with extended search', :type => :request do
+  let(:scope_filters) { { 'scopes' => {}, 'team' => { 'id' => '1', 'name' => 'Operations' } } }
+
+  # NOTICE: `Kiwi Tree` matches the search on its own column, `Lemon Tree` matches
+  #         only through `owner.name`, and `Apple Tree` matches nothing. Extended
+  #         search must therefore return 2 records, plain search 1.
+  before(:each) do
+    Tree.destroy_all
+    Location.destroy_all
+    Island.destroy_all
+    User.destroy_all
+
+    michel = User.create(name: 'Michel')
+    kiwi_grower = User.create(name: 'Kiwi Grower')
+    @island = Island.create(name: 'Home Island')
+
+    Tree.create(name: 'Kiwi Tree', owner: michel, cutter: michel, island: @island)
+    Tree.create(name: 'Lemon Tree', owner: kiwi_grower, cutter: michel, island: @island)
+    Tree.create(name: 'Apple Tree', owner: michel, cutter: michel, island: @island)
+
+    allow(ForestLiana::IpWhitelist).to receive(:retrieve) { true }
+    allow(ForestLiana::IpWhitelist).to receive(:is_ip_whitelist_retrieved) { true }
+    allow(ForestLiana::IpWhitelist).to receive(:is_ip_valid) { true }
+
+    allow_any_instance_of(ForestLiana::Ability).to receive(:forest_authorize!) { true }
+
+    allow(ForestLiana::ScopeManager).to receive(:fetch_scopes).and_return(scope_filters)
+  end
+
+  after(:each) do
+    Tree.destroy_all
+    Location.destroy_all
+    Island.destroy_all
+    User.destroy_all
+  end
+
+  token = JWT.encode({
+                       id: 38,
+                       email: 'michael.kelso@that70.show',
+                       first_name: 'Michael',
+                       last_name: 'Kelso',
+                       team: 'Operations',
+                       rendering_id: 16,
+                       exp: Time.now.to_i + 2.weeks.to_i,
+                       permission_level: 'admin'
+                     }, ForestLiana.auth_secret, 'HS256')
+
+  headers = {
+    'Accept' => 'application/json',
+    'Content-Type' => 'application/json',
+    'Authorization' => "Bearer #{token}"
+  }
+
+  def count_returned
+    JSON.parse(response.body)['count']
+  end
+
+  def records_returned
+    JSON.parse(response.body)['data'].size
+  end
+
+  describe 'count' do
+    let(:projection) { { 'Tree' => 'id,name,owner' } }
+    let(:params) {
+      {
+        page: { 'number' => '1', 'size' => '10' },
+        search: 'kiwi',
+        searchExtended: '1',
+        timezone: 'Europe/Paris'
+      }
+    }
+
+    describe 'when the request carries no fields' do
+      it 'responds 200 with the number of records the list returns for the same search' do
+        get '/forest/Tree', params: params, headers: headers
+        listed = records_returned
+
+        get '/forest/Tree/count', params: params, headers: headers
+
+        expect(response.status).to eq(200)
+        expect(count_returned).to eq(2)
+        expect(count_returned).to eq(listed)
+      end
+    end
+
+    describe 'when the request carries fields' do
+      it 'responds 200 with the number of records the list returns for the same search' do
+        get '/forest/Tree', params: params.merge(fields: projection), headers: headers
+        listed = records_returned
+
+        get '/forest/Tree/count', params: params.merge(fields: projection), headers: headers
+
+        expect(response.status).to eq(200)
+        expect(count_returned).to eq(2)
+        expect(count_returned).to eq(listed)
+      end
+    end
+
+    describe 'when the same count is requested twice' do
+      it 'returns the same count both times' do
+        get '/forest/Tree/count', params: params, headers: headers
+        first_count = count_returned
+
+        get '/forest/Tree/count', params: params, headers: headers
+
+        expect(response.status).to eq(200)
+        expect(count_returned).to eq(2)
+        expect(count_returned).to eq(first_count)
+      end
+    end
+
+    describe 'when extended search is off' do
+      it 'counts only the records matching on their own columns' do
+        get '/forest/Tree', params: params.merge(searchExtended: '0'), headers: headers
+        listed = records_returned
+
+        get '/forest/Tree/count', params: params.merge(searchExtended: '0'), headers: headers
+
+        expect(response.status).to eq(200)
+        expect(count_returned).to eq(1)
+        expect(count_returned).to eq(listed)
+      end
+    end
+
+    describe 'when searchExtended is absent from the request' do
+      it 'counts only the records matching on their own columns' do
+        get '/forest/Tree/count', params: params.except(:searchExtended), headers: headers
+
+        expect(response.status).to eq(200)
+        expect(count_returned).to eq(1)
+      end
+    end
+
+    describe 'when the search matches no record at all' do
+      it 'responds 200 with a count of zero' do
+        get '/forest/Tree', params: params.merge(search: 'sequoia'), headers: headers
+        listed = records_returned
+
+        get '/forest/Tree/count', params: params.merge(search: 'sequoia'), headers: headers
+
+        expect(response.status).to eq(200)
+        expect(count_returned).to eq(0)
+        expect(count_returned).to eq(listed)
+      end
+    end
+
+    describe 'when the search is an empty string' do
+      it 'counts every record' do
+        get '/forest/Tree/count', params: params.merge(search: ''), headers: headers
+
+        expect(response.status).to eq(200)
+        expect(count_returned).to eq(3)
+      end
+    end
+
+    describe 'when the request carries no search at all' do
+      it 'counts every record' do
+        get '/forest/Tree/count', params: params.except(:search), headers: headers
+
+        expect(response.status).to eq(200)
+        expect(count_returned).to eq(3)
+      end
+    end
+  end
+
+  describe 'count on relationships' do
+    let(:projection) { { 'Tree' => 'id,name' } }
+    let(:params) {
+      {
+        page: { 'number' => '1', 'size' => '10' },
+        search: 'kiwi',
+        searchExtended: '1',
+        timezone: 'Europe/Paris'
+      }
+    }
+
+    describe 'when the count carries no fields and the list carries the projection' do
+      it 'counts the number of records the related list returns' do
+        get "/forest/Island/#{@island.id}/relationships/trees",
+            params: params.merge(fields: projection), headers: headers
+        listed = records_returned
+
+        get "/forest/Island/#{@island.id}/relationships/trees/count", params: params, headers: headers
+
+        expect(response.status).to eq(200)
+        expect(count_returned).to eq(2)
+        expect(count_returned).to eq(listed)
+      end
+    end
+
+    describe 'when both the count and the list carry the projection' do
+      it 'counts the number of records the related list returns' do
+        get "/forest/Island/#{@island.id}/relationships/trees",
+            params: params.merge(fields: projection), headers: headers
+        listed = records_returned
+
+        get "/forest/Island/#{@island.id}/relationships/trees/count",
+            params: params.merge(fields: projection), headers: headers
+
+        expect(response.status).to eq(200)
+        expect(count_returned).to eq(2)
+        expect(count_returned).to eq(listed)
+      end
+    end
+
+    describe 'when extended search is off' do
+      it 'counts only the related records matching on their own columns' do
+        get "/forest/Island/#{@island.id}/relationships/trees",
+            params: params.merge(searchExtended: '0', fields: projection), headers: headers
+        listed = records_returned
+
+        get "/forest/Island/#{@island.id}/relationships/trees/count",
+            params: params.merge(searchExtended: '0'), headers: headers
+
+        expect(response.status).to eq(200)
+        expect(count_returned).to eq(1)
+        expect(count_returned).to eq(listed)
+      end
+    end
+
+    describe 'when the related search matches no record at all' do
+      it 'responds 200 with a count of zero' do
+        get "/forest/Island/#{@island.id}/relationships/trees/count",
+            params: params.merge(search: 'sequoia'), headers: headers
+
+        expect(response.status).to eq(200)
+        expect(count_returned).to eq(0)
+      end
+    end
+
+    describe 'when the parent record has no related record' do
+      it 'responds 200 with a count of zero' do
+        empty_island = Island.create(name: 'Empty Island')
+
+        get "/forest/Island/#{empty_island.id}/relationships/trees/count", params: params, headers: headers
+
+        expect(response.status).to eq(200)
+        expect(count_returned).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/services/forest_liana/has_many_getter_spec.rb
+++ b/spec/services/forest_liana/has_many_getter_spec.rb
@@ -189,6 +189,68 @@ module ForestLiana
             expect(subject.records.count).to eq 1
           end
         end
+
+        describe 'serializing the related records' do
+          let(:projection) { { 'Tree' => 'id,name,owner' } }
+
+          it 'serializes only the associations the projection asked for' do
+            expect(subject.includes_for_serialization).to eq ['owner']
+          end
+        end
+
+        describe 'serializing the related records when no projection was requested' do
+          it 'serializes every association the search reaches' do
+            expect(subject.includes_for_serialization)
+              .to match_array(%w[owner cutter island eponymous_island location])
+          end
+        end
+      end
+
+      describe 'when the related collection has an association in another database' do
+        let(:association) { Manufacturer.reflect_on_association(:products) }
+        let(:search) { 'zzz' }
+        let(:params) {
+          ActiveSupport::HashWithIndifferentAccess.new(
+            id: Manufacturer.first.id,
+            association_name: 'products',
+            search: search,
+            searchExtended: '1',
+            fields: { 'Product' => 'id,name' },
+            page: { size: 15, number: 1 },
+            timezone: 'America/Nome'
+          )
+        }
+
+        subject { described_class.new(Manufacturer, association, params, user) }
+
+        before(:each) do
+          manufacturer = Manufacturer.create!(name: 'Acme')
+          driver = Driver.create!(firstname: 'Zed')
+          Product.create!(
+            name: 'Widget', uri: 'https://widget.example',
+            manufacturer: manufacturer, driver: driver
+          )
+        end
+
+        after(:each) do
+          Product.destroy_all
+          Manufacturer.destroy_all
+          Driver.destroy_all
+        end
+
+        it 'does not search columns the eager load cannot join' do
+          expect(subject.count).to eq 0
+          expect(subject.records.count).to eq 0
+        end
+
+        describe 'when the search matches an association in the same database' do
+          let(:search) { 'acme' }
+
+          it 'still matches through that association' do
+            expect(subject.count).to eq 1
+            expect(subject.records.count).to eq 1
+          end
+        end
       end
 
       describe 'compute_includes' do

--- a/spec/services/forest_liana/has_many_getter_spec.rb
+++ b/spec/services/forest_liana/has_many_getter_spec.rb
@@ -114,6 +114,83 @@ module ForestLiana
         end
       end
 
+      describe 'when searching with extended search' do
+        # HashWithIndifferentAccess: the code reads @params['searchExtended'] (string),
+        # as the controller hands it an ActionController::Parameters.
+        let(:projection) { nil }
+        let(:searchExtended) { '1' }
+        let(:params) {
+          ActiveSupport::HashWithIndifferentAccess.new(
+            id: Island.first.id,
+            association_name: 'trees',
+            search: 'kiwi',
+            searchExtended: searchExtended,
+            fields: projection,
+            page: { size: 15, number: 1 },
+            timezone: 'America/Nome'
+          )
+        }
+
+        # NOTICE: `kiwi tree` matches on its own name and `coconut tree` matches only
+        #         through `owner.name`, so extended search matches 2 of madagascar's
+        #         trees where plain search matches 1.
+        before(:each) do
+          kiwi_grower = User.create(name: 'Kiwi Grower')
+          Tree.create(name: 'kiwi tree', island: Island.first)
+          Tree.create(name: 'coconut tree', island: Island.first, owner: kiwi_grower)
+        end
+
+        after(:each) do
+          User.destroy_all
+        end
+
+        describe 'when the request carries no fields' do
+          it 'counts the related records it returns' do
+            subject.perform
+
+            expect(subject.count).to eq 2
+            expect(subject.records.count).to eq 2
+          end
+        end
+
+        describe 'when the request carries fields' do
+          let(:projection) { { 'Tree' => 'id,name' } }
+
+          it 'counts the same related records as the request carrying no fields' do
+            subject.perform
+
+            expect(subject.count).to eq 2
+            expect(subject.records.count).to eq 2
+          end
+        end
+
+        describe 'when the count carries no fields and the list carries the projection' do
+          it 'announces the number of related records the list returns' do
+            listed = described_class.new(
+              Island,
+              association,
+              params.merge(fields: { 'Tree' => 'id,name' }),
+              user
+            )
+            listed.perform
+
+            expect(subject.count).to eq 2
+            expect(listed.records.count).to eq 2
+          end
+        end
+
+        describe 'when extended search is off' do
+          let(:searchExtended) { '0' }
+
+          it 'counts only the related records matching on their own columns' do
+            subject.perform
+
+            expect(subject.count).to eq 1
+            expect(subject.records.count).to eq 1
+          end
+        end
+      end
+
       describe 'compute_includes' do
         it 'should include has_one relation from association' do
           expect(subject.includes).to include(:location)
@@ -152,6 +229,21 @@ module ForestLiana
         it 'should exclude Tree associations when models not included' do
           allow(SchemaUtils).to receive(:model_included?).and_return(false)
           expect(subject.includes).to be_empty
+        end
+
+        it 'should not narrow the includes by the requested fields when extended search is on' do
+          extended_params = ActiveSupport::HashWithIndifferentAccess.new(
+            id: Island.first.id,
+            association_name: 'trees',
+            search: 'kiwi',
+            searchExtended: '1',
+            fields: { 'Tree' => 'owner,island' },
+            page: { size: 15, number: 1 },
+            timezone: 'America/Nome'
+          )
+          getter = described_class.new(Island, association, extended_params, user)
+
+          expect(getter.includes).to match_array(%i[owner cutter island eponymous_island location])
         end
 
         context 'on polymorphic associations' do

--- a/spec/services/forest_liana/resources_getter_spec.rb
+++ b/spec/services/forest_liana/resources_getter_spec.rb
@@ -628,5 +628,84 @@ module ForestLiana
         end
       end
     end
+
+    describe 'when searching with extended search' do
+      let(:resource) { Tree }
+      let(:search) { 'skull' }
+      let(:searchExtended) { '1' }
+      let(:requested_fields) { nil }
+
+      # HashWithIndifferentAccess: the code reads @params['searchExtended'] (string),
+      # as the controller hands it an ActionController::Parameters.
+      let(:search_params) {
+        ActiveSupport::HashWithIndifferentAccess.new(
+          page: { size: pageSize, number: pageNumber },
+          search: search,
+          searchExtended: searchExtended,
+          fields: requested_fields,
+          timezone: 'Europe/Paris',
+        )
+      }
+
+      # NOTICE: the count route builds a getter and calls #count on it without ever
+      #         calling #perform, so the list getter has to be a separate instance —
+      #         #perform rewrites @records with the eager loads and would hide the defect.
+      let(:getter) { described_class.new(resource, search_params, user) }
+      let(:list_getter) { described_class.new(resource, search_params, user) }
+
+      # NOTICE: `Lemon Tree` and `Ginger Tree` both grow on the island `Skull`, and no
+      #         tree carries `skull` in its own name — so extended search matches 2
+      #         records where plain search matches none.
+      describe 'when no fields are requested' do
+        it 'counts the records the list returns instead of failing on the un-joined association' do
+          list_getter.perform
+
+          expect(getter.count).to eq 2
+          expect(list_getter.records.count).to eq 2
+        end
+
+        it 'eager loads every one-association the search predicates reach' do
+          expect(getter.includes).to contain_exactly(:owner, :cutter, :island, :eponymous_island, :location)
+        end
+      end
+
+      describe 'when fields are requested' do
+        let(:requested_fields) { { 'Tree' => 'id,name' } }
+
+        it 'counts the same records as the request carrying no fields' do
+          list_getter.perform
+
+          expect(getter.count).to eq 2
+          expect(list_getter.records.count).to eq 2
+        end
+
+        it 'eager loads the same associations as the request carrying no fields' do
+          expect(getter.includes).to contain_exactly(:owner, :cutter, :island, :eponymous_island, :location)
+        end
+      end
+
+      describe 'when extended search is off' do
+        let(:searchExtended) { '0' }
+
+        it 'matches on the own columns only and counts none of the associated records' do
+          list_getter.perform
+
+          expect(getter.count).to eq 0
+          expect(list_getter.records.count).to eq 0
+          expect(getter.includes).to eq []
+        end
+      end
+
+      describe 'when the search is nil' do
+        let(:search) { nil }
+
+        it 'counts every record' do
+          list_getter.perform
+
+          expect(getter.count).to eq 5
+          expect(list_getter.records.count).to eq 5
+        end
+      end
+    end
   end
 end

--- a/spec/services/forest_liana/resources_getter_spec.rb
+++ b/spec/services/forest_liana/resources_getter_spec.rb
@@ -664,7 +664,7 @@ module ForestLiana
           expect(list_getter.records.count).to eq 2
         end
 
-        it 'eager loads every one-association the search predicates reach' do
+        it 'keeps every one-association in the include set when no fields are requested' do
           expect(getter.includes).to contain_exactly(:owner, :cutter, :island, :eponymous_island, :location)
         end
       end
@@ -679,7 +679,7 @@ module ForestLiana
           expect(list_getter.records.count).to eq 2
         end
 
-        it 'eager loads the same associations as the request carrying no fields' do
+        it 'keeps the same include set when fields are requested' do
           expect(getter.includes).to contain_exactly(:owner, :cutter, :island, :eponymous_island, :location)
         end
       end
@@ -704,6 +704,33 @@ module ForestLiana
 
           expect(getter.count).to eq 5
           expect(list_getter.records.count).to eq 5
+        end
+      end
+
+      # NOTICE: Island's one-associations are `location` and the instance-dependent
+      #         `eponymous_tree`. Nothing else joins `trees`, so a predicate naming it
+      #         has no FROM entry — the shape `Tree` hides, since `eponymous_island`
+      #         resolves against the `isle` join `island` already contributes.
+      describe 'when a one-association carries an instance-dependent scope' do
+        let(:resource) { Island }
+        let(:search) { 'skull' }
+
+        it 'searches the own columns without failing on the un-joined association' do
+          list_getter.perform
+
+          expect(getter.count).to eq 1
+          expect(list_getter.records.count).to eq 1
+        end
+
+        describe 'when the search matches through an association the eager load does join' do
+          let(:search) { '12345' }
+
+          it 'still matches through that association' do
+            list_getter.perform
+
+            expect(getter.count).to eq 1
+            expect(list_getter.records.count).to eq 1
+          end
         end
       end
     end


### PR DESCRIPTION
Closes [PRD-1034](https://linear.app/forestadmin/issue/PRD-1034/forest-rails-extended-search-returns-no-count-500-and-an-inflated)

## What breaks today

With extended search on, against any `forest_liana` project:

- **Top-level list — the count is gone.** `GET /forest/:collection/count` returns **500** (`PG::UndefinedTable: missing FROM-clause entry`). The table lists the right records; only the count fails.
- **Related data — the count is too high, silently.** The relationship tab lists N records and announces more than N.

Nothing changed in the gem. The front stopped sending `fields[...]` on `/count` in 2.1245.0 (13 Aug), correctly reasoning that a count never serializes records. `forest_liana` derives **search behaviour** from that parameter, not just serialization: `fields` is what armed the JOINs the extended-search predicates need. The hole dates to the 2017 count optimisation (#117) and sat latent for eight years because the front always sent `fields`.

Note this also restores a documented recipe: `/legacy/ruby-agent/.../override-a-route` tells you to set `params['searchExtended'] = '1'` on **both** `index` and `count`. That recipe 500s on `main`.

## The fix

Root cause of everything below: a single `@includes` was serving three different jobs — which tables the search may name, which the query eager-loads, and which get serialized. They are not the same set.

**`resources_getter.rb` — the 500.** `@count_needs_includes` was set as a side effect of `extract_associations_from_filter`, which `searchExtended=1` never reaches (`compute_includes` takes the `else` branch, and `field_names_requested` early-returns on the missing `fields`). It now comes from the params in `initialize`, so `count` eager-loads and the association columns in the `WHERE` have a `FROM` entry.

`!@params[:search].nil?` rather than `.present?` is deliberate — `search=''` still builds `LIKE '%%'` predicates (`search_query_builder.rb:60` guards on `if @search`, and `''` is truthy), so `present?` would leave that case broken. A test pins it.

**`has_many_getter.rb` — the inflated count.** `compute_includes` narrowed the association set by the projection only when that set was non-empty, so a count with no projection searched every association while the list searched only the projected ones. Under `searchExtended=1` the footprint is now projection-independent, mirroring `ResourcesGetter#compute_includes`.

**`has_many_getter.rb` — the two sets that must not be shared.** Making the footprint projection-independent surfaced two things the first commit got wrong, both caught in review and fixed in 575f05a:

- `SearchQueryBuilder` now receives `searchable_includes` — `@includes` minus what `analyze_associations` rejects (polymorphic, cross-database, instance-dependent scopes). Without this, a related list with a cross-database association returned **500**: the predicate named a table `optimize_record_loading` had dropped from the eager load. `@includes` itself is untouched, so those associations keep their `preload`.
- `includes_for_serialization` is overridden to clamp back to the projection, as `ResourcesGetter` already did. Without it the related list answered with every association plus a populated `included` array, ignoring the `fields[...]` the client sent.

## Behaviour change worth a look

**The related list returns 2 where it returned 1** for an extended search carrying a projection. The count was always right; the list was under-searching. Making the footprint projection-independent costs the related list an eager-load of all one-associations under extended search — the cost the top-level list already pays. Narrowing the count instead isn't available: the count has no projection left to narrow by.

Outside the extended-search path nothing moves. `@count_needs_includes` can now only go false→true, never the reverse, so no existing count path loses its eager-load. And `Calculations#calculate` forces `COUNT(DISTINCT pk)` on any eager-loaded relation, so the widened set cannot inflate a count — including via the HABTM member of `SUPPORTED_ASSOCIATION_MACROS`, which the dummy app has no model to exercise.

## Tests

There was **no coverage of `searchExtended=1` anywhere in the repo** — every spec passed `'0'`. That is why this shipped. 28 tests added, written red before each fix.

| | revert `resources_getter` | revert `has_many_getter` (a11cc22) | revert `has_many_getter` (575f05a) |
| -- | -- | -- | -- |
| `count_spec.rb` | 4 fail | 2 fail | — |
| `resources_getter_spec.rb` | 1 fail | 0 | — |
| `has_many_getter_spec.rb` | 0 | 3 fail | 3 fail |

Each fix is independently guarded. Where a scenario has both a count and a list, the test asserts `count == list length` **and** the absolute number, so a wrong-but-consistent pair can't pass.

Verified unaffected, not assumed: `composite_primary_keys`, `resources_getter_composite_keys`, `filters_parser`, `search_query_builder`.

## Verified on PostgreSQL

The whole suite runs on sqlite, and the reported symptom is a PG error — so both symptoms were reproduced on a local Postgres 15 rig and confirmed fixed, merge-base vs branch, same rig and data:

| Request (`search=kiwi`, `searchExtended=1`) | `c416ff7` | `575f05a` |
| -- | -- | -- |
| `GET /forest/Tree/count` — no `fields` | **500** | `{"count":2}` |
| `GET /forest/Island/1/relationships/trees/count` — no `fields` | `{"count":2}` | `{"count":2}` |
| `GET /forest/Island/1/relationships/trees?fields[Tree]=id,name` | **1 row** | **2 rows**, keys `[id, name]` |

Also checked there: `count` + `sort=-id` returns 200 — PostgreSQL rejects `SELECT DISTINCT … ORDER BY <expr outside the select list>`, and this PR routes counts through `optimized_count` in cases that previously skipped it. SQLite cannot expose that failure class.

And a genuine cross-engine case (PG primary + SQLite secondary): the related list and count both return 200, while a search matching only via `manufacturer.name` still returns `{"count":1}` — the search set was narrowed to joinable tables without narrowing too far.

## Not in this PR

- `has_many` association filters (`trees_owned:name`) 500 with `ambiguous column name` on both the list and the count, regardless of `searchExtended`. Different defect, seen only against the dummy models.
- A collection declaring `search_fields` with a dotted `has_many` entry still 500s on `/count` under extended search — pre-existing, static analysis only.
- `query_for_batch` has the same missing-join hole one accessor over, reachable from a bulk action over "select all records" — pre-existing.
- An ADR is owed for choosing to widen the list's footprint over implementing the `Forest-Projection` header (PRD-928). `docs/adr/**` lives in another repo.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix count queries to search the same columns as list queries
> - Adds `BaseGetter#searchable_includes` to compute only the associations that eager loading actually joins (excluding polymorphic and preload-only associations).
> - `HasManyGetter` and `ResourcesGetter` now pass `searchable_includes` to `SearchQueryBuilder` instead of the raw includes list, so counts search the same columns as their corresponding listings.
> - When `searchExtended` is enabled (`searchExtended=1`), includes are no longer narrowed by the requested field projection; the full set of one-to-one associations is retained for both count and list.
> - `ResourcesGetter` constructor now sets `@count_needs_includes = true` whenever a search parameter is present, replacing a redundant assignment in `extract_associations_from_filter`.
> - Behavioral Change: count queries for searches now include association joins they previously lacked, which may change count results for filtered searches; reviewers should check `ResourcesGetter#initialize` and `HasManyGetter#initialize`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e553f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->