### PR TITLE
fix(has-many-getter): gate extended search on nil, not present, search

### DIFF
--- a/app/services/forest_liana/has_many_getter.rb
+++ b/app/services/forest_liana/has_many_getter.rb
@@ -183,8 +183,11 @@ module ForestLiana
     # every included one-association's columns and relies on its table already being joined.
     # Mirror the associations it can reach so their JOIN stays eager instead of moving to
     # preload (which never joins, on any Rails version).
+    #
+    # NOTICE: `!nil?`, not `.present?` — search_param guards on `if @search`, and `''` is
+    # truthy, so an empty search string still needs the JOIN.
     def associations_referenced_by_extended_search
-      return [] unless @params[:search].present? && @params['searchExtended'].to_i == 1
+      return [] unless !@params[:search].nil? && @params['searchExtended'].to_i == 1
 
       target_model = model_association
       includes_symbols = @includes.map(&:to_sym)

--- a/app/services/forest_liana/has_many_getter.rb
+++ b/app/services/forest_liana/has_many_getter.rb
@@ -194,11 +194,8 @@ module ForestLiana
     # every included one-association's columns and relies on its table already being joined.
     # Mirror the associations it can reach so their JOIN stays eager instead of moving to
     # preload (which never joins, on any Rails version).
-    #
-    # NOTICE: `!nil?`, not `.present?` — search_param guards on `if @search`, and `''` is
-    # truthy, so an empty search string still needs the JOIN.
     def associations_referenced_by_extended_search
-      return [] unless !@params[:search].nil? && @params['searchExtended'].to_i == 1
+      return [] unless @params[:search].present? && @params['searchExtended'].to_i == 1
 
       target_model = model_association
       includes_symbols = @includes.map(&:to_sym)

--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -6,7 +6,7 @@ module ForestLiana
       @resource = resource
       @params = params
       @user = forest_user
-      @count_needs_includes = !@params[:search].nil?
+      @count_needs_includes = @params[:search].present?
       @collection_name = ForestLiana.name_for(@resource)
       @collection = get_collection(@collection_name)
       @fields_to_serialize = get_fields_to_serialize

--- a/app/services/forest_liana/search_query_builder.rb
+++ b/app/services/forest_liana/search_query_builder.rb
@@ -9,7 +9,8 @@ module ForestLiana
       @includes = includes
       @collection = collection
       @fields_searched = []
-      @search = @params[:search]
+      # '' is truthy, so without .presence an empty search still builds LIKE '%%' predicates.
+      @search = @params[:search].presence
       @user = user
     end
 

--- a/spec/services/forest_liana/has_many_getter_pagination_spec.rb
+++ b/spec/services/forest_liana/has_many_getter_pagination_spec.rb
@@ -158,5 +158,25 @@ module ForestLiana
         expect(records.map(&:name)).to contain_exactly('cedar', 'pine')
       end
     end
+
+    describe 'with extended search and an empty search string' do
+      let(:params) do
+        {
+          id: island.id,
+          association_name: 'trees',
+          search: '',
+          'searchExtended' => '1',
+          page: { size: 15, number: 1 },
+          timezone: 'America/Nome'
+        }
+      end
+
+      it 'keeps the display association joined instead of raising on the un-joined table' do
+        subject.perform
+
+        expect { subject.records.to_a }.not_to raise_error
+        expect(subject.records.to_a.map(&:name)).to contain_exactly('cedar', 'olive', 'pine', 'fig')
+      end
+    end
   end
 end

--- a/spec/services/forest_liana/has_many_getter_pagination_spec.rb
+++ b/spec/services/forest_liana/has_many_getter_pagination_spec.rb
@@ -171,11 +171,12 @@ module ForestLiana
         }
       end
 
-      it 'keeps the display association joined instead of raising on the un-joined table' do
+      it 'treats an empty search as a no-op instead of building predicates it cannot join' do
         subject.perform
 
         expect { subject.records.to_a }.not_to raise_error
         expect(subject.records.to_a.map(&:name)).to contain_exactly('cedar', 'olive', 'pine', 'fig')
+        expect(subject.count).to eq(@trees.size)
       end
 
       describe 'with a record whose searched columns are all NULL' do

--- a/spec/services/forest_liana/has_many_getter_pagination_spec.rb
+++ b/spec/services/forest_liana/has_many_getter_pagination_spec.rb
@@ -177,6 +177,16 @@ module ForestLiana
         expect { subject.records.to_a }.not_to raise_error
         expect(subject.records.to_a.map(&:name)).to contain_exactly('cedar', 'olive', 'pine', 'fig')
       end
+
+      describe 'with a record whose searched columns are all NULL' do
+        before(:each) { Tree.create!(name: nil, island: island) }
+
+        it 'is a no-op, not a filter: the record is still returned' do
+          subject.perform
+
+          expect(subject.records.to_a.map(&:name)).to contain_exactly('cedar', 'olive', 'pine', 'fig', nil)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What breaks today (main / 9.20.11)

With extended search on (`searchExtended=1`) and an **empty** search string, a has-many related list 500s:

```
GET /forest/Island/:id/relationships/trees?search=&searchExtended=1
→ ActiveRecord::StatementInvalid: SQLite3::SQLException: no such column: users.name
```

## First fix: gate on `nil`, not `present?`

`associations_referenced_by_extended_search` (introduced in #790) decided whether a display-only association must stay eager-loaded, gated on `@params[:search].present?`.

`SearchQueryBuilder#search_param` guards on `if @search` instead, and `''` is truthy in Ruby — so an empty search string still built `LIKE '%%'` predicates against every included one-association's table. `.present?` is `false` for `''`, so the association moved to `preload` (no JOIN) while the predicate still ran against it: missing FROM-clause entry.

`ResourcesGetter` already hit this exact distinction and uses `!@params[:search].nil?` for the same reason. First commit aligned `HasManyGetter`'s gate with it.

## Second fix: the actual root cause — `''` should be a no-op, not a filter

Review on this PR flagged that gating on presence just patches the symptom: with the first fix alone, `search=''` stopped 500ing but became a real *filter* — `LOWER(NULL) LIKE '%%'` evaluates to `NULL` in SQL, so a record whose searched columns are all `NULL` is silently excluded under `search=''` while present with no `search` param at all.

Root cause: `SearchQueryBuilder#initialize` kept `@search = @params[:search]` as-is, so every `if @search` check downstream treated `''` as truthy. Fixed at the source with `.presence`, so `''` behaves like `nil` everywhere.

This retires both `!nil?`-instead-of-`.present?` workarounds now that `''` no longer needs the extra JOIN/eager-load:
- `has_many_getter.rb#associations_referenced_by_extended_search` → back to `.present?`
- `resources_getter.rb`'s `@count_needs_includes` (from #791) → back to `.present?`

## Tests

- Regression spec for the original 500 (has_many_getter_pagination_spec.rb), red before the first fix.
- New spec: a record with `name: nil` and no owner is present under extended search with no `search` param, and stays present under `search=''` — red before the second fix (confirmed by reverting locally).

Full suite: 498 examples, 0 failures.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ## What breaks today (main / 9.20.11)
>
> With extended search on (`searchExtended=1`) and an **empty** search string, a has-many related list 500s:
>
> ```
> GET /forest/Island/:id/relationships/trees?search=&searchExtended=1
> → ActiveRecord::StatementInvalid: SQLite3::SQLException: no such column: users.name
> ```
>
> ## First fix: gate on `nil`, not `present?`
>
> `associations_referenced_by_extended_search` (introduced in #790) decided whether a display-only association must stay eager-loaded, gated on `@params[:search].present?`.
>
> `SearchQueryBuilder#search_param` guards on `if @search` instead, and `''` is truthy in Ruby — so an empty search string still built `LIKE '%%'` predicates against every included one-association's table. `.present?` is `false` for `''`, so the association moved to `preload` (no JOIN) while the predicate still ran against it: missing FROM-clause entry.
>
> `ResourcesGetter` already hit this exact distinction and uses `!@params[:search].nil?` for the same reason. First commit aligned `HasManyGetter`'s gate with it.
>
> ## Second fix: the actual root cause — `''` should be a no-op, not a filter
>
> Review on this PR flagged that gating on presence just patches the symptom: with the first fix alone, `search=''` stopped 500ing but became a real *filter* — `LOWER(NULL) LIKE '%%'` evaluates to `NULL` in SQL, so a record whose searched columns are all `NULL` is silently excluded under `search=''` while present with no `search` param at all.
>
> Root cause: `SearchQueryBuilder#initialize` kept `@search = @params[:search]` as-is, so every `if @search` check downstream treated `''` as truthy. Fixed at the source with `.presence`, so `''` behaves like `nil` everywhere.
>
> This retires both `!nil?`-instead-of-`.present?` workarounds now that `''` no longer needs the extra JOIN/eager-load:
> - `has_many_getter.rb#associations_referenced_by_extended_search` → back to `.present?`
> - `resources_getter.rb`'s `@count_needs_includes` (from #791) → back to `.present?`
>
> ## Tests
>
> - Regression spec for the original 500 (has_many_getter_pagination_spec.rb), red before the first fix.
> - New spec: a record with `name: nil` and no owner is present under extended search with no `search` param, and stays present under `search=''` — red before the second fix (confirmed by reverting locally).
>
> Full suite: 498 examples, 0 failures.<!-- Macroscope's changelog starts here -->
> #### Changes since #792 opened
>
> - Renamed RSpec example description for `ForestLiana::HasManyGetter` pagination spec and added count assertion [045a126]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->