### PR TITLE
feat(actions): resolve select-all selections for approval-required actions

### DIFF
--- a/app/controllers/forest_liana/smart_actions_controller.rb
+++ b/app/controllers/forest_liana/smart_actions_controller.rb
@@ -2,6 +2,7 @@ module ForestLiana
   class SmartActionsController < ForestLiana::ApplicationController
     rescue_from ForestLiana::Ability::Exceptions::TriggerForbidden, with: :render_error
     rescue_from ForestLiana::Ability::Exceptions::RequireApproval, with: :render_error
+    rescue_from ForestLiana::Ability::Exceptions::ApprovalSelectionTooLarge, with: :render_error
     rescue_from ForestLiana::Ability::Exceptions::ActionConditionError, with: :render_error
     include ForestLiana::Ability
     if Rails::VERSION::MAJOR < 4

--- a/app/services/forest_liana/ability/exceptions/approval_selection_too_large.rb
+++ b/app/services/forest_liana/ability/exceptions/approval_selection_too_large.rb
@@ -1,0 +1,17 @@
+module ForestLiana
+  module Ability
+    module Exceptions
+      class ApprovalSelectionTooLarge < ForestLiana::Errors::ExpectedError
+        def initialize(max, backtrace = nil)
+          super(
+            422,
+                :unprocessable_entity,
+                "This action requires approval and cannot be triggered on more than #{max} records at once. Please refine your selection.",
+                'ApprovalSelectionTooLargeError',
+            backtrace,
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/forest_liana/ability/exceptions/require_approval.rb
+++ b/app/services/forest_liana/ability/exceptions/require_approval.rb
@@ -3,8 +3,12 @@ module ForestLiana
     module Exceptions
       class RequireApproval < ForestLiana::Errors::ExpectedError
         attr_reader :data
-        def initialize(data, backtrace = nil)
-          @data = data
+        # record_ids is only set for a "select all" trigger: the frontend has no explicit id list
+        # in that case, so the resolved (capped) ids are handed back to be stored in the approval
+        # request.
+        def initialize(role_ids_allowed_to_approve, backtrace = nil, record_ids = nil)
+          @data = { roleIdsAllowedToApprove: role_ids_allowed_to_approve }
+          @data[:recordIds] = record_ids if record_ids
           super(
             403,
                 :forbidden,

--- a/app/services/forest_liana/ability/exceptions/require_approval.rb
+++ b/app/services/forest_liana/ability/exceptions/require_approval.rb
@@ -3,9 +3,6 @@ module ForestLiana
     module Exceptions
       class RequireApproval < ForestLiana::Errors::ExpectedError
         attr_reader :data
-        # record_ids is only set for a "select all" trigger: the frontend has no explicit id list
-        # in that case, so the resolved (capped) ids are handed back to be stored in the approval
-        # request.
         def initialize(role_ids_allowed_to_approve, backtrace = nil, record_ids = nil)
           @data = { roleIdsAllowedToApprove: role_ids_allowed_to_approve }
           @data[:recordIds] = record_ids if record_ids

--- a/app/services/forest_liana/ability/permission.rb
+++ b/app/services/forest_liana/ability/permission.rb
@@ -39,9 +39,11 @@ module ForestLiana
         collections_data = get_collections_permissions_data
         collection_name = ForestLiana.name_for(collection)
         begin
-          action = find_action_from_endpoint(collection_name, endpoint, http_method).name
+          schema_action = find_action_from_endpoint(collection_name, endpoint, http_method)
 
-          smart_action_approval = SmartActionChecker.new(parameters, collection, collections_data[collection_name][:actions][action], user_data)
+          # The schema type rides along so the checker can skip select-all resolution for
+          # global actions, which target no specific records.
+          smart_action_approval = SmartActionChecker.new(parameters, collection, collections_data[collection_name][:actions][schema_action.name], user_data, schema_action.type)
           smart_action_approval.can_execute?
         rescue ForestLiana::Errors::ExpectedError => exception
           raise exception

--- a/app/services/forest_liana/ability/permission.rb
+++ b/app/services/forest_liana/ability/permission.rb
@@ -41,7 +41,7 @@ module ForestLiana
         begin
           schema_action = find_action_from_endpoint(collection_name, endpoint, http_method)
 
-          smart_action_approval = SmartActionChecker.new(parameters, collection, collections_data[collection_name][:actions][schema_action.name], user_data, schema_action.type)
+          smart_action_approval = SmartActionChecker.new(parameters, collection, collections_data[collection_name][:actions][schema_action.name], user_data, schema_action.type, user)
           smart_action_approval.can_execute?
         rescue ForestLiana::Errors::ExpectedError => exception
           raise exception

--- a/app/services/forest_liana/ability/permission.rb
+++ b/app/services/forest_liana/ability/permission.rb
@@ -41,8 +41,6 @@ module ForestLiana
         begin
           schema_action = find_action_from_endpoint(collection_name, endpoint, http_method)
 
-          # The schema type rides along so the checker can skip select-all resolution for
-          # global actions, which target no specific records.
           smart_action_approval = SmartActionChecker.new(parameters, collection, collections_data[collection_name][:actions][schema_action.name], user_data, schema_action.type)
           smart_action_approval.can_execute?
         rescue ForestLiana::Errors::ExpectedError => exception

--- a/app/services/forest_liana/ability/permission/smart_action_checker.rb
+++ b/app/services/forest_liana/ability/permission/smart_action_checker.rb
@@ -2,8 +2,7 @@ module ForestLiana
   module Ability
     module Permission
       class SmartActionChecker
-        # Max number of records a "select all" approval request may target. Matches the Forest
-        # server's hard cap on approval record ids - keep in sync.
+        # The Forest server's hard cap on approval record ids - keep in sync.
         MAX_RECORDS_FOR_APPROVAL = 500
 
         def initialize(parameters, collection, smart_action, user, action_type = nil)
@@ -40,9 +39,7 @@ module ForestLiana
             return true if condition_by_role_id(@smart_action['triggerConditions']).blank? || match_conditions('triggerConditions')
           elsif @smart_action['approvalRequired'].include?(@user['roleId'])
             if condition_by_role_id(@smart_action['approvalRequiredConditions']).blank? || match_conditions('approvalRequiredConditions')
-              # On a "select all" trigger the frontend has no explicit id list to store in the
-              # approval request: resolve the selection here (capped) and hand the ids back
-              # through the error. Global actions target no specific records — never resolve.
+              # Global actions target no specific records — never resolve.
               if @parameters[:data][:attributes][:all_records] && @action_type != 'global'
                 record_ids = select_all_record_ids
               end
@@ -57,8 +54,7 @@ module ForestLiana
         end
 
         def select_all_record_ids
-          # Fetch at most cap + excluded + 1 raw ids: enough to detect an over-cap selection
-          # after exclusions are filtered out, without materializing the whole table.
+          # cap + excluded + 1 raw ids suffice to detect an over-cap selection after exclusions.
           excluded_ids = @parameters[:data][:attributes][:all_records_ids_excluded] || []
           ids = ForestLiana::ResourcesGetter.get_ids_from_request(
             @parameters, @user, limit: MAX_RECORDS_FOR_APPROVAL + excluded_ids.length + 1
@@ -68,8 +64,7 @@ module ForestLiana
             raise ForestLiana::Ability::Exceptions::ApprovalSelectionTooLarge.new(MAX_RECORDS_FOR_APPROVAL)
           end
 
-          # Composite primary keys come back as arrays: encode them the way the serializer
-          # builds record ids (SerializerFactory#id), so the frontend gets the format it uses.
+          # Composite pks come back as arrays: encode them like SerializerFactory#id does.
           ids.map { |id| id.is_a?(Array) ? id.to_json : id }
         end
 

--- a/app/services/forest_liana/ability/permission/smart_action_checker.rb
+++ b/app/services/forest_liana/ability/permission/smart_action_checker.rb
@@ -5,12 +5,15 @@ module ForestLiana
         # The Forest server's hard cap on approval record ids - keep in sync.
         MAX_RECORDS_FOR_APPROVAL = 500
 
-        def initialize(parameters, collection, smart_action, user, action_type = nil)
+        # `user` is the permissions-API user (id/roleId); `forest_user` is the JWT user, the one
+        # ResourcesGetter needs (rendering_id for scopes).
+        def initialize(parameters, collection, smart_action, user, action_type = nil, forest_user = nil)
           @parameters = parameters
           @collection = collection
           @smart_action = smart_action
           @user = user
           @action_type = action_type
+          @forest_user = forest_user
         end
 
         def can_execute?
@@ -54,10 +57,16 @@ module ForestLiana
         end
 
         def select_all_record_ids
-          # cap + excluded + 1 raw ids suffice to detect an over-cap selection after exclusions.
           excluded_ids = @parameters[:data][:attributes][:all_records_ids_excluded] || []
+
+          # The exclusion list is client-controlled: it must not re-inflate the bounded fetch.
+          if excluded_ids.length > MAX_RECORDS_FOR_APPROVAL
+            raise ForestLiana::Ability::Exceptions::ApprovalSelectionTooLarge.new(MAX_RECORDS_FOR_APPROVAL)
+          end
+
+          # cap + excluded + 1 raw ids suffice to detect an over-cap selection after exclusions.
           ids = ForestLiana::ResourcesGetter.get_ids_from_request(
-            @parameters, @user, limit: MAX_RECORDS_FOR_APPROVAL + excluded_ids.length + 1
+            @parameters, @forest_user, limit: MAX_RECORDS_FOR_APPROVAL + excluded_ids.length + 1
           )
 
           if ids.length > MAX_RECORDS_FOR_APPROVAL
@@ -65,7 +74,12 @@ module ForestLiana
           end
 
           # Composite pks come back as arrays: encode them like SerializerFactory#id does.
-          ids.map { |id| id.is_a?(Array) ? id.to_json : id }
+          ids.map { |id| id.is_a?(Array) ? id.to_json : id.to_s }
+        rescue ForestLiana::Errors::ExpectedError
+          raise
+        rescue StandardError => exception
+          FOREST_LOGGER.error "Select all record ids resolution error: #{exception.message}"
+          raise ForestLiana::Errors::HTTP422Error.new('Unable to resolve the "select all" selection')
         end
 
         def match_conditions(condition_name)

--- a/app/services/forest_liana/ability/permission/smart_action_checker.rb
+++ b/app/services/forest_liana/ability/permission/smart_action_checker.rb
@@ -2,6 +2,9 @@ module ForestLiana
   module Ability
     module Permission
       class SmartActionChecker
+        # Max number of records a "select all" approval request may target. Matches the Forest
+        # server's hard cap on approval record ids - keep in sync.
+        MAX_RECORDS_FOR_APPROVAL = 500
 
         def initialize(parameters, collection, smart_action, user)
           @parameters = parameters
@@ -36,13 +39,28 @@ module ForestLiana
             return true if condition_by_role_id(@smart_action['triggerConditions']).blank? || match_conditions('triggerConditions')
           elsif @smart_action['approvalRequired'].include?(@user['roleId'])
             if condition_by_role_id(@smart_action['approvalRequiredConditions']).blank? || match_conditions('approvalRequiredConditions')
-              raise ForestLiana::Ability::Exceptions::RequireApproval.new(@smart_action['userApprovalEnabled'])
+              # On a "select all" trigger the frontend has no explicit id list to store in the
+              # approval request: resolve the selection here (capped) and hand the ids back
+              # through the error.
+              record_ids = select_all_record_ids if @parameters[:data][:attributes][:all_records]
+
+              raise ForestLiana::Ability::Exceptions::RequireApproval.new(@smart_action['userApprovalEnabled'], nil, record_ids)
             else
               return true if condition_by_role_id(@smart_action['triggerConditions']).blank? || match_conditions('triggerConditions')
             end
           end
 
           raise ForestLiana::Ability::Exceptions::TriggerForbidden.new
+        end
+
+        def select_all_record_ids
+          ids = ForestLiana::ResourcesGetter.get_ids_from_request(@parameters, @user)
+
+          if ids.length > MAX_RECORDS_FOR_APPROVAL
+            raise ForestLiana::Ability::Exceptions::ApprovalSelectionTooLarge.new(MAX_RECORDS_FOR_APPROVAL)
+          end
+
+          ids
         end
 
         def match_conditions(condition_name)

--- a/app/services/forest_liana/ability/permission/smart_action_checker.rb
+++ b/app/services/forest_liana/ability/permission/smart_action_checker.rb
@@ -6,11 +6,12 @@ module ForestLiana
         # server's hard cap on approval record ids - keep in sync.
         MAX_RECORDS_FOR_APPROVAL = 500
 
-        def initialize(parameters, collection, smart_action, user)
+        def initialize(parameters, collection, smart_action, user, action_type = nil)
           @parameters = parameters
           @collection = collection
           @smart_action = smart_action
           @user = user
+          @action_type = action_type
         end
 
         def can_execute?
@@ -41,8 +42,10 @@ module ForestLiana
             if condition_by_role_id(@smart_action['approvalRequiredConditions']).blank? || match_conditions('approvalRequiredConditions')
               # On a "select all" trigger the frontend has no explicit id list to store in the
               # approval request: resolve the selection here (capped) and hand the ids back
-              # through the error.
-              record_ids = select_all_record_ids if @parameters[:data][:attributes][:all_records]
+              # through the error. Global actions target no specific records — never resolve.
+              if @parameters[:data][:attributes][:all_records] && @action_type != 'global'
+                record_ids = select_all_record_ids
+              end
 
               raise ForestLiana::Ability::Exceptions::RequireApproval.new(@smart_action['userApprovalEnabled'], nil, record_ids)
             else

--- a/app/services/forest_liana/ability/permission/smart_action_checker.rb
+++ b/app/services/forest_liana/ability/permission/smart_action_checker.rb
@@ -68,7 +68,9 @@ module ForestLiana
             raise ForestLiana::Ability::Exceptions::ApprovalSelectionTooLarge.new(MAX_RECORDS_FOR_APPROVAL)
           end
 
-          ids
+          # Composite primary keys come back as arrays: encode them the way the serializer
+          # builds record ids (SerializerFactory#id), so the frontend gets the format it uses.
+          ids.map { |id| id.is_a?(Array) ? id.to_json : id }
         end
 
         def match_conditions(condition_name)

--- a/app/services/forest_liana/ability/permission/smart_action_checker.rb
+++ b/app/services/forest_liana/ability/permission/smart_action_checker.rb
@@ -54,7 +54,12 @@ module ForestLiana
         end
 
         def select_all_record_ids
-          ids = ForestLiana::ResourcesGetter.get_ids_from_request(@parameters, @user)
+          # Fetch at most cap + excluded + 1 raw ids: enough to detect an over-cap selection
+          # after exclusions are filtered out, without materializing the whole table.
+          excluded_ids = @parameters[:data][:attributes][:all_records_ids_excluded] || []
+          ids = ForestLiana::ResourcesGetter.get_ids_from_request(
+            @parameters, @user, limit: MAX_RECORDS_FOR_APPROVAL + excluded_ids.length + 1
+          )
 
           if ids.length > MAX_RECORDS_FOR_APPROVAL
             raise ForestLiana::Ability::Exceptions::ApprovalSelectionTooLarge.new(MAX_RECORDS_FOR_APPROVAL)

--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -19,13 +19,13 @@ module ForestLiana
       @base_records_for_batch = @records
     end
 
-    def self.get_ids_from_request(params, user)
+    def self.get_ids_from_request(params, user, limit: nil)
       attributes = params.dig('data', 'attributes')
       return attributes[:ids] if attributes&.fetch(:all_records, false) == false && attributes[:ids]
 
       attributes = merge_subset_query(attributes)
       resources_getter = initialize_resources_getter(attributes, user)
-      ids = fetch_ids(resources_getter)
+      ids = fetch_ids(resources_getter, limit: limit)
 
       filter_excluded_ids(ids, attributes[:all_records_ids_excluded])
     end
@@ -256,11 +256,14 @@ module ForestLiana
       ]
     end
 
-    def self.fetch_ids(resources_getter)
+    def self.fetch_ids(resources_getter, limit: nil)
       ids = []
-      resources_getter.query_for_batch.find_in_batches { |records| ids += records.map(&:id) }
+      resources_getter.query_for_batch.find_in_batches do |records|
+        ids += records.map(&:id)
+        break if limit && ids.length >= limit
+      end
 
-      ids
+      limit ? ids.first(limit) : ids
     end
 
     def self.filter_excluded_ids(ids, ids_excluded)

--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -267,7 +267,11 @@ module ForestLiana
     end
 
     def self.filter_excluded_ids(ids, ids_excluded)
-      ids_excluded ? ids.reject { |id| ids_excluded.map(&:to_s).include?(id.to_s) } : ids
+      return ids if ids_excluded.blank?
+
+      excluded = ids_excluded.map(&:to_s)
+      # Composite pks are arrays; the frontend excludes them in their serialized JSON form.
+      ids.reject { |id| excluded.include?(id.is_a?(Array) ? id.to_json : id.to_s) }
     end
 
     def search_query

--- a/spec/services/forest_liana/ability/permission/smart_action_checker_spec.rb
+++ b/spec/services/forest_liana/ability/permission/smart_action_checker_spec.rb
@@ -209,6 +209,24 @@ module ForestLiana
             .with(anything, forest_user, limit: 501)
         end
 
+        it 'should widen the fetch limit by the exclusion list size' do
+          select_all_params = params.deep_dup
+          select_all_params['data']['attributes'][:all_records] = true
+          select_all_params['data']['attributes'][:ids] = []
+          select_all_params['data']['attributes'][:all_records_ids_excluded] = (1..100).map(&:to_s)
+          parameters = ActionController::Parameters.new(select_all_params).permit!
+          action['approvalRequired'] = [1]
+          action['userApprovalEnabled'] = [7]
+          allow(ForestLiana::ResourcesGetter).to receive(:get_ids_from_request).and_return((1..500).map(&:to_s))
+          smart_action_checker = ForestLiana::Ability::Permission::SmartActionChecker.new(parameters, Island, action, user, nil, forest_user)
+
+          expect{smart_action_checker.can_execute?}.to raise_error(ForestLiana::Ability::Exceptions::RequireApproval)
+          # Without the excluded term, a 600-record / 100-excluded selection silently
+          # resolves to 401 ids instead of the full 500.
+          expect(ForestLiana::ResourcesGetter).to have_received(:get_ids_from_request)
+            .with(anything, forest_user, limit: 601)
+        end
+
         it 'should encode composite primary keys the way the serializer builds record ids' do
           select_all_params = params.deep_dup
           select_all_params['data']['attributes'][:all_records] = true

--- a/spec/services/forest_liana/ability/permission/smart_action_checker_spec.rb
+++ b/spec/services/forest_liana/ability/permission/smart_action_checker_spec.rb
@@ -173,6 +173,51 @@ module ForestLiana
           expect{smart_action_checker.can_execute?}.to raise_error ForestLiana::Ability::Exceptions::RequireApproval
         end
 
+        it 'should expose the approver role ids and skip record ids on an explicit selection' do
+          parameters = ActionController::Parameters.new(params).permit!
+          action['approvalRequired'] = [1]
+          action['userApprovalEnabled'] = [7]
+          allow(ForestLiana::ResourcesGetter).to receive(:get_ids_from_request)
+          smart_action_checker = ForestLiana::Ability::Permission::SmartActionChecker.new(parameters, Island, action, user)
+
+          expect{smart_action_checker.can_execute?}.to raise_error(ForestLiana::Ability::Exceptions::RequireApproval) do |error|
+            expect(error.data[:roleIdsAllowedToApprove]).to eq([7])
+            expect(error.data).not_to have_key(:recordIds)
+          end
+          expect(ForestLiana::ResourcesGetter).not_to have_received(:get_ids_from_request)
+        end
+
+        it 'should include the resolved record ids in the error on a "select all" trigger' do
+          select_all_params = params.deep_dup
+          select_all_params['data']['attributes'][:all_records] = true
+          select_all_params['data']['attributes'][:ids] = []
+          parameters = ActionController::Parameters.new(select_all_params).permit!
+          action['approvalRequired'] = [1]
+          action['userApprovalEnabled'] = [7]
+          allow(ForestLiana::ResourcesGetter).to receive(:get_ids_from_request).and_return(%w[1 2 3])
+          smart_action_checker = ForestLiana::Ability::Permission::SmartActionChecker.new(parameters, Island, action, user)
+
+          expect{smart_action_checker.can_execute?}.to raise_error(ForestLiana::Ability::Exceptions::RequireApproval) do |error|
+            expect(error.data[:roleIdsAllowedToApprove]).to eq([7])
+            expect(error.data[:recordIds]).to eq(%w[1 2 3])
+          end
+        end
+
+        it 'should refuse a "select all" trigger resolving over 500 record ids' do
+          select_all_params = params.deep_dup
+          select_all_params['data']['attributes'][:all_records] = true
+          select_all_params['data']['attributes'][:ids] = []
+          parameters = ActionController::Parameters.new(select_all_params).permit!
+          action['approvalRequired'] = [1]
+          allow(ForestLiana::ResourcesGetter).to receive(:get_ids_from_request).and_return((1..501).map(&:to_s))
+          smart_action_checker = ForestLiana::Ability::Permission::SmartActionChecker.new(parameters, Island, action, user)
+
+          expect{smart_action_checker.can_execute?}.to raise_error(
+            ForestLiana::Ability::Exceptions::ApprovalSelectionTooLarge,
+            /more than 500 records/
+          )
+        end
+
         it 'should raise RequireApproval error if match approvalRequiredConditions' do
           parameters = ActionController::Parameters.new(params).permit!
           action['approvalRequired'] = [1]

--- a/spec/services/forest_liana/ability/permission/smart_action_checker_spec.rb
+++ b/spec/services/forest_liana/ability/permission/smart_action_checker_spec.rb
@@ -206,6 +206,22 @@ module ForestLiana
             .with(anything, anything, limit: 501)
         end
 
+        it 'should not resolve record ids on a "select all" trigger of a global action' do
+          select_all_params = params.deep_dup
+          select_all_params['data']['attributes'][:all_records] = true
+          select_all_params['data']['attributes'][:ids] = []
+          parameters = ActionController::Parameters.new(select_all_params).permit!
+          action['approvalRequired'] = [1]
+          action['userApprovalEnabled'] = [7]
+          allow(ForestLiana::ResourcesGetter).to receive(:get_ids_from_request)
+          smart_action_checker = ForestLiana::Ability::Permission::SmartActionChecker.new(parameters, Island, action, user, 'global')
+
+          expect{smart_action_checker.can_execute?}.to raise_error(ForestLiana::Ability::Exceptions::RequireApproval) do |error|
+            expect(error.data).not_to have_key(:recordIds)
+          end
+          expect(ForestLiana::ResourcesGetter).not_to have_received(:get_ids_from_request)
+        end
+
         it 'should refuse a "select all" trigger resolving over 500 record ids' do
           select_all_params = params.deep_dup
           select_all_params['data']['attributes'][:all_records] = true

--- a/spec/services/forest_liana/ability/permission/smart_action_checker_spec.rb
+++ b/spec/services/forest_liana/ability/permission/smart_action_checker_spec.rb
@@ -206,6 +206,21 @@ module ForestLiana
             .with(anything, anything, limit: 501)
         end
 
+        it 'should encode composite primary keys the way the serializer builds record ids' do
+          select_all_params = params.deep_dup
+          select_all_params['data']['attributes'][:all_records] = true
+          select_all_params['data']['attributes'][:ids] = []
+          parameters = ActionController::Parameters.new(select_all_params).permit!
+          action['approvalRequired'] = [1]
+          action['userApprovalEnabled'] = [7]
+          allow(ForestLiana::ResourcesGetter).to receive(:get_ids_from_request).and_return([[1, 'abc'], [2, 'def']])
+          smart_action_checker = ForestLiana::Ability::Permission::SmartActionChecker.new(parameters, Island, action, user)
+
+          expect{smart_action_checker.can_execute?}.to raise_error(ForestLiana::Ability::Exceptions::RequireApproval) do |error|
+            expect(error.data[:recordIds]).to eq(['[1,"abc"]', '[2,"def"]'])
+          end
+        end
+
         it 'should not resolve record ids on a "select all" trigger of a global action' do
           select_all_params = params.deep_dup
           select_all_params['data']['attributes'][:all_records] = true

--- a/spec/services/forest_liana/ability/permission/smart_action_checker_spec.rb
+++ b/spec/services/forest_liana/ability/permission/smart_action_checker_spec.rb
@@ -187,6 +187,8 @@ module ForestLiana
           expect(ForestLiana::ResourcesGetter).not_to have_received(:get_ids_from_request)
         end
 
+        let(:forest_user) { { 'id' => 1, 'rendering_id' => 13 } }
+
         it 'should include the resolved record ids in the error on a "select all" trigger' do
           select_all_params = params.deep_dup
           select_all_params['data']['attributes'][:all_records] = true
@@ -194,16 +196,17 @@ module ForestLiana
           parameters = ActionController::Parameters.new(select_all_params).permit!
           action['approvalRequired'] = [1]
           action['userApprovalEnabled'] = [7]
-          allow(ForestLiana::ResourcesGetter).to receive(:get_ids_from_request).and_return(%w[1 2 3])
-          smart_action_checker = ForestLiana::Ability::Permission::SmartActionChecker.new(parameters, Island, action, user)
+          allow(ForestLiana::ResourcesGetter).to receive(:get_ids_from_request).and_return([1, 2, 3])
+          smart_action_checker = ForestLiana::Ability::Permission::SmartActionChecker.new(parameters, Island, action, user, nil, forest_user)
 
           expect{smart_action_checker.can_execute?}.to raise_error(ForestLiana::Ability::Exceptions::RequireApproval) do |error|
             expect(error.data[:roleIdsAllowedToApprove]).to eq([7])
             expect(error.data[:recordIds]).to eq(%w[1 2 3])
           end
-          # cap + excluded ids (none here) + 1: bounds the fetch instead of materializing the table
+          # cap + excluded ids (none here) + 1: bounds the fetch instead of materializing the table.
+          # The JWT user (not the permissions one) must be used: scopes need its rendering_id.
           expect(ForestLiana::ResourcesGetter).to have_received(:get_ids_from_request)
-            .with(anything, anything, limit: 501)
+            .with(anything, forest_user, limit: 501)
         end
 
         it 'should encode composite primary keys the way the serializer builds record ids' do
@@ -214,7 +217,7 @@ module ForestLiana
           action['approvalRequired'] = [1]
           action['userApprovalEnabled'] = [7]
           allow(ForestLiana::ResourcesGetter).to receive(:get_ids_from_request).and_return([[1, 'abc'], [2, 'def']])
-          smart_action_checker = ForestLiana::Ability::Permission::SmartActionChecker.new(parameters, Island, action, user)
+          smart_action_checker = ForestLiana::Ability::Permission::SmartActionChecker.new(parameters, Island, action, user, nil, forest_user)
 
           expect{smart_action_checker.can_execute?}.to raise_error(ForestLiana::Ability::Exceptions::RequireApproval) do |error|
             expect(error.data[:recordIds]).to eq(['[1,"abc"]', '[2,"def"]'])
@@ -244,11 +247,43 @@ module ForestLiana
           parameters = ActionController::Parameters.new(select_all_params).permit!
           action['approvalRequired'] = [1]
           allow(ForestLiana::ResourcesGetter).to receive(:get_ids_from_request).and_return((1..501).map(&:to_s))
-          smart_action_checker = ForestLiana::Ability::Permission::SmartActionChecker.new(parameters, Island, action, user)
+          smart_action_checker = ForestLiana::Ability::Permission::SmartActionChecker.new(parameters, Island, action, user, nil, forest_user)
 
           expect{smart_action_checker.can_execute?}.to raise_error(
             ForestLiana::Ability::Exceptions::ApprovalSelectionTooLarge,
             /more than 500 records/
+          )
+        end
+
+        it 'should refuse a "select all" trigger with an oversized exclusion list without querying' do
+          select_all_params = params.deep_dup
+          select_all_params['data']['attributes'][:all_records] = true
+          select_all_params['data']['attributes'][:ids] = []
+          select_all_params['data']['attributes'][:all_records_ids_excluded] = (1..501).map(&:to_s)
+          parameters = ActionController::Parameters.new(select_all_params).permit!
+          action['approvalRequired'] = [1]
+          allow(ForestLiana::ResourcesGetter).to receive(:get_ids_from_request)
+          smart_action_checker = ForestLiana::Ability::Permission::SmartActionChecker.new(parameters, Island, action, user, nil, forest_user)
+
+          expect{smart_action_checker.can_execute?}.to raise_error(
+            ForestLiana::Ability::Exceptions::ApprovalSelectionTooLarge
+          )
+          expect(ForestLiana::ResourcesGetter).not_to have_received(:get_ids_from_request)
+        end
+
+        it 'should raise a 422 when the id resolution fails unexpectedly' do
+          select_all_params = params.deep_dup
+          select_all_params['data']['attributes'][:all_records] = true
+          select_all_params['data']['attributes'][:ids] = []
+          parameters = ActionController::Parameters.new(select_all_params).permit!
+          action['approvalRequired'] = [1]
+          allow(ForestLiana::ResourcesGetter).to receive(:get_ids_from_request)
+            .and_raise(StandardError.new('Unable to fetch scopes'))
+          smart_action_checker = ForestLiana::Ability::Permission::SmartActionChecker.new(parameters, Island, action, user, nil, forest_user)
+
+          expect{smart_action_checker.can_execute?}.to raise_error(
+            ForestLiana::Errors::HTTP422Error,
+            /Unable to resolve/
           )
         end
 

--- a/spec/services/forest_liana/ability/permission/smart_action_checker_spec.rb
+++ b/spec/services/forest_liana/ability/permission/smart_action_checker_spec.rb
@@ -201,6 +201,9 @@ module ForestLiana
             expect(error.data[:roleIdsAllowedToApprove]).to eq([7])
             expect(error.data[:recordIds]).to eq(%w[1 2 3])
           end
+          # cap + excluded ids (none here) + 1: bounds the fetch instead of materializing the table
+          expect(ForestLiana::ResourcesGetter).to have_received(:get_ids_from_request)
+            .with(anything, anything, limit: 501)
         end
 
         it 'should refuse a "select all" trigger resolving over 500 record ids' do

--- a/spec/services/forest_liana/resources_getter_spec.rb
+++ b/spec/services/forest_liana/resources_getter_spec.rb
@@ -166,6 +166,16 @@ module ForestLiana
       end
     end
 
+    describe '.fetch_ids' do
+      it 'returns all the matching ids when no limit is given' do
+        expect(described_class.fetch_ids(getter).length).to eq 30
+      end
+
+      it 'returns at most limit ids' do
+        expect(described_class.fetch_ids(getter, limit: 5).length).to eq 5
+      end
+    end
+
     describe 'when on a model having a reserved SQL word as name' do
       let(:resource) { Reference }
       let(:fields) { { resource.name => 'id' } }

--- a/spec/services/forest_liana/resources_getter_spec.rb
+++ b/spec/services/forest_liana/resources_getter_spec.rb
@@ -176,6 +176,22 @@ module ForestLiana
       end
     end
 
+    describe '.filter_excluded_ids' do
+      it 'removes excluded simple ids' do
+        expect(described_class.filter_excluded_ids([1, 2, 3], ['2'])).to eq [1, 3]
+      end
+
+      it 'removes excluded composite ids given in their serialized JSON form' do
+        expect(described_class.filter_excluded_ids([[1, 'abc'], [2, 'def']], ['[1,"abc"]']))
+          .to eq [[2, 'def']]
+      end
+
+      it 'returns the ids untouched without exclusions' do
+        expect(described_class.filter_excluded_ids([1, 2], [])).to eq [1, 2]
+        expect(described_class.filter_excluded_ids([1, 2], nil)).to eq [1, 2]
+      end
+    end
+
     describe 'when on a model having a reserved SQL word as name' do
       let(:resource) { Reference }
       let(:fields) { { resource.name => 'id' } }


### PR DESCRIPTION
## Summary

forest-rails port of ForestAdmin/agent-nodejs#1847 — enabling bulk actions with approval on "select all" selections.

- When `SmartActionChecker` decides a trigger requires approval and the request has `all_records: true`, it resolves the selection to concrete ids via the existing `ResourcesGetter.get_ids_from_request` (filters/search/segment + exclusions) and hands them back through the error → `errors[0].data.recordIds`, so the frontend stores the full target set in the approval request instead of the current page.
- Selections over **500** records are rejected with `ApprovalSelectionTooLargeError` (422), matching the Forest server's authoritative cap on approval record ids. Normal executes are unchanged.
- `RequireApproval`'s data is now a structured hash with `roleIdsAllowedToApprove` — the key the frontend actually reads (it previously received a bare array, which the frontend ignores).
- Also fixes a pre-existing bug for composite-primary-key collections: `ResourcesGetter.filter_excluded_ids` compared array pks against their serialized JSON exclusion form and never matched, so "select all + exclude" bulk delete (`resources_controller`) and dissociate (`has_many_dissociator`) were acting on the excluded records too. The comparison is now normalized at the source, fixing all callers.

## Related PRs

- agent-nodejs: ForestAdmin/agent-nodejs#1847
- agent-ruby: ForestAdmin/agent-ruby#374
- forest-express: ForestAdmin/forest-express#1064
- Frontend (uses `data.recordIds`, with a fetch-based backport for agents without this feature): ForestAdmin/forestadmin#9924
- Server (authoritative 500 cap): ForestAdmin/forestadmin-server#8462

fixes PRD-934

## Test plan

- [x] smart_action_checker specs: resolved ids in the error on select-all, over-cap rejection, no resolution on explicit selections, approver-roles key (20 pass)
- [x] Full suite: 23 minitest runs + 501 rspec examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve record IDs for select-all approval triggers and cap at 500 in `SmartActionChecker`
> - For non-global smart actions requiring approval, `SmartActionChecker` now resolves and returns bounded record IDs in the 403 `RequireApproval` error so approvers know which records are targeted.
> - Introduces `MAX_RECORDS_FOR_APPROVAL = 500` in `SmartActionChecker`; oversized selections raise the new 422 `ApprovalSelectionTooLarge` exception.
> - `RequireApproval` now carries `roleIdsAllowedToApprove` and conditionally `recordIds`; `Permission.is_smart_action_authorized?` passes the action type and JWT user to the checker so scopes are honored.
> - `ResourcesGetter.get_ids_from_request` and `fetch_ids` accept an optional `limit` for early-termination ID retrieval; `filter_excluded_ids` now handles composite primary keys via JSON-serialized comparison.
> - Behavioral Change: `RequireApproval` initializer signature changed from an arbitrary data object to explicit `role_ids_allowed_to_approve`, `backtrace`, and `record_ids` params — any out-of-tree callers constructing this exception directly will break. `SmartActionsController` now rescues `ApprovalSelectionTooLarge` and returns 422 instead of propagating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f660e68.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
