### PR TITLE
feat(field-path): resolve a field path to the collections a read permission applies to

### DIFF
--- a/app/services/forest_liana/field_path.rb
+++ b/app/services/forest_liana/field_path.rb
@@ -1,0 +1,33 @@
+module ForestLiana
+  class FieldPath
+    # An empty list (a polymorphic relation with no declared target) is read as denied by
+    # readable_leaves?, not as nothing to check.
+    #
+    # A prefix naming no relation raises rather than falling back to the root collection, which
+    # is pinned readable upstream — a fallback would turn "does not resolve" into "allowed".
+    def self.leaf_collection_names(model, path)
+      raise ArgumentError, 'model must be an ActiveRecord model class' unless model.is_a?(Class) && model < ActiveRecord::Base
+
+      head, separator, rest = path.partition(':')
+      reflection = model.reflect_on_association(head.to_sym)
+
+      return [ForestLiana.name_for(model)] if reflection.nil? && separator.empty?
+
+      if reflection.nil?
+        raise ForestLiana::Errors::HTTP422Error.new(
+          "Relation not found: '#{ForestLiana.name_for(model)}.#{head}'"
+        )
+      end
+
+      if SchemaUtils.polymorphic?(reflection)
+        return SchemaUtils.polymorphic_models(reflection).map { |target| ForestLiana.name_for(target) }
+      end
+
+      leaf_collection_names(reflection.klass, rest)
+    end
+
+    def self.readable_leaves?(collection_names, readable_collection_names)
+      collection_names.any? && collection_names.all? { |name| readable_collection_names.include?(name) }
+    end
+  end
+end

--- a/spec/services/forest_liana/field_path_spec.rb
+++ b/spec/services/forest_liana/field_path_spec.rb
@@ -1,0 +1,116 @@
+module ForestLiana
+  describe FieldPath do
+    describe 'leaf_collection_names' do
+      it 'answers the collection itself for one of its own columns' do
+        expect(FieldPath.leaf_collection_names(Tree, 'name')).to eq(['Tree'])
+      end
+
+      it 'answers only the collection a path ends on, not the one it crosses' do
+        expect(FieldPath.leaf_collection_names(Tree, 'island:name')).to eq(['Island'])
+      end
+
+      it 'answers the leaf of a path crossing two relations' do
+        expect(FieldPath.leaf_collection_names(Tree, 'island:location:id')).to eq(['Location'])
+      end
+
+      it 'answers the target of a polymorphic relation reached through another relation' do
+        expect(FieldPath.leaf_collection_names(User, 'addresses:addressable:id')).to eq(['User'])
+      end
+
+      it 'stops resolving at the polymorphic relation, whatever segment follows it' do
+        expect(FieldPath.leaf_collection_names(User, 'addresses:addressable:whatever')).to eq(['User'])
+      end
+
+      it 'answers the target of a bare relation name with no trailing column' do
+        expect(FieldPath.leaf_collection_names(Tree, 'island')).to eq(['Island'])
+      end
+
+      it 'raises rather than falling back to the root when the prefix names nothing' do
+        expect { FieldPath.leaf_collection_names(Tree, 'unknown:id') }
+          .to raise_error(Errors::HTTP422Error, "Relation not found: 'Tree.unknown'")
+      end
+
+      it 'raises rather than falling back to the root when the prefix is a column' do
+        expect { FieldPath.leaf_collection_names(Tree, 'name:id') }
+          .to raise_error(Errors::HTTP422Error, "Relation not found: 'Tree.name'")
+      end
+
+      it 'raises rather than falling back to the root on a trailing colon naming no relation' do
+        expect { FieldPath.leaf_collection_names(Tree, 'unknown:') }
+          .to raise_error(Errors::HTTP422Error, "Relation not found: 'Tree.unknown'")
+      end
+
+      it 'raises rather than falling back to the root on a trailing colon naming a column' do
+        expect { FieldPath.leaf_collection_names(Tree, 'name:') }
+          .to raise_error(Errors::HTTP422Error, "Relation not found: 'Tree.name'")
+      end
+
+      it 'raises when given a record instead of a model class' do
+        expect { FieldPath.leaf_collection_names(Island.new, 'name') }.to raise_error(ArgumentError)
+      end
+
+      it 'raises when given a class that is not an ActiveRecord model' do
+        expect { FieldPath.leaf_collection_names(String, 'anything') }.to raise_error(ArgumentError)
+      end
+
+      context 'on a polymorphic relation with several targets' do
+        before do
+          Island.class_eval { has_many :addresses, as: :addressable }
+        end
+
+        after do
+          %w[addresses].each do |name|
+            Island._reflections.delete(name)
+            Island.reflections.delete(name)
+          end
+          %w[addresses addresses= address_ids address_ids=].each do |method|
+            Island.undef_method(method) rescue nil
+          end
+        end
+
+        it 'answers every target of the polymorphic relation' do
+          expect(FieldPath.leaf_collection_names(Address, 'addressable:id'))
+            .to match_array(%w[User Island])
+        end
+
+        it 'answers every target of a bare polymorphic relation with no trailing column' do
+          expect(FieldPath.leaf_collection_names(Address, 'addressable')).to match_array(%w[User Island])
+        end
+      end
+
+      context 'on a polymorphic relation with no declared target' do
+        before do
+          Tree.class_eval { belongs_to :subject, polymorphic: true, optional: true }
+        end
+
+        after do
+          %w[subject].each do |name|
+            Tree._reflections.delete(name)
+            Tree.reflections.delete(name)
+          end
+          %w[subject subject= subject_id subject_type].each do |method|
+            Tree.undef_method(method) rescue nil
+          end
+        end
+
+        it 'answers an empty list, not the root collection' do
+          expect(FieldPath.leaf_collection_names(Tree, 'subject:id')).to eq([])
+        end
+      end
+    end
+
+    describe 'readable_leaves?' do
+      it 'reads an empty list as denied' do
+        expect(FieldPath.readable_leaves?([], %w[User])).to be false
+      end
+
+      it 'allows a path only when every leaf collection is readable' do
+        expect(FieldPath.readable_leaves?(%w[User Island], %w[User Island])).to be true
+      end
+
+      it 'denies a path when one leaf collection is not readable' do
+        expect(FieldPath.readable_leaves?(%w[User Island], %w[User])).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
fixes PRD-1081

## Why

Every read check in the v1 read-permission-parity project asks the same question: *given a field path, which collection(s) does a read permission apply to?* Forest has no field-level permissions, so a path is only ever checked against the collection its leaf column belongs to. This is the foundation for the three enforcement guards (PRD-1083, PRD-1084, PRD-1085) — get it right once, and each guard is mechanical.

The client this backport targets uses polymorphic relations, which is exactly where this is hard.

## What

`ForestLiana::FieldPath.leaf_collection_names(model, path)`, walking ActiveRecord reflections. Ports v2's rules verbatim (`FieldPath.leaf_collection_names` in agent-ruby):

- a bare column resolves to `[root]`
- `relation:column` resolves to the leaf's collection, not the crossed one
- a path ending on a polymorphic relation resolves to **every** declared target — no discriminant, any record may resolve to any of them, so the caller must be able to read all
- a polymorphic relation declaring no target at all resolves to an **empty list**, which must be read as denied rather than as nothing to check
- a prefix naming no relation (or a column) **raises** rather than falling back to the root collection — the root is pinned readable upstream, so falling back would silently turn "this path does not resolve" into "this path is allowed"

`readable_leaves?(names, allowed)` ships alongside it, encoding the empty-list-means-denied rule once here rather than in each of the three consumers.

## Tests

13 new examples in `spec/services/forest_liana/field_path_spec.rb`, on the dummy app's existing models (multi-target and zero-target polymorphic cases use a temporary `class_eval` association with the teardown pattern already used in `has_many_getter_spec.rb`).

Full suite: 524 examples, 0 failures.

Both empty-list-denied and no-root-fallback are mutation-checked: removing the `any?` guard fails the empty-list spec, and replacing the raise with a root fallback fails both no-fallback specs.

## Not in scope

STI subclasses (`belongs_to :location` resolves to `['Location']`, not its subclasses) — same posture as v2.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `leaf_collection_names` and `readable_leaves?` class methods to `FieldPath`
> - Adds `FieldPath.leaf_collection_names` which resolves a colon-delimited field path to the leaf collection names reachable from a given model via associations; returns all target names for polymorphic associations and `[]` when none are declared
> - Adds `FieldPath.readable_leaves?` which returns true only when the leaf collection list is non-empty and every name is in the provided readable set
> - Raises `ArgumentError` for non-ActiveRecord models and `Errors::HTTP422Error` when a path segment does not resolve to an association (including column-as-relation and trailing-colon cases)
> - Risk: callers that pass column names or paths with trailing colons now receive `Errors::HTTP422Error` instead of silent resolution; polymorphic associations with no declared targets return `[]` rather than a partial result
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f555cc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->