### PR TITLE
feat(permissions): refuse a filter or sort reading a collection the role cannot read

### DIFF
--- a/app/controllers/forest_liana/application_controller.rb
+++ b/app/controllers/forest_liana/application_controller.rb
@@ -10,6 +10,7 @@ module ForestLiana
     rescue_from ForestLiana::Ability::Exceptions::ActionConditionError, with: :render_error
     rescue_from ForestLiana::Ability::Exceptions::UnknownCollection, with: :render_error
     rescue_from ForestLiana::Ability::Exceptions::UnauthorizedFieldsError, with: :render_error
+    rescue_from ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError, with: :render_error
 
     def self.papertrail?
       Object.const_get('PaperTrail::Version').is_a?(Class) rescue false

--- a/app/controllers/forest_liana/associations_controller.rb
+++ b/app/controllers/forest_liana/associations_controller.rb
@@ -123,6 +123,13 @@ module ForestLiana
         head :no_content
       rescue ActiveRecord::RecordNotDestroyed => error
         render json: { errors: [{ status: :bad_request, detail: error.message }] }, status: :bad_request
+      rescue ForestLiana::Errors::ExpectedError => error
+        error.display_error
+        error_data = ForestAdmin::JSONAPI::Serializer.serialize_errors([{
+          status: error.error_code,
+          detail: error.message
+        }])
+        render(serializer: nil, json: error_data, status: error.status)
       rescue => error
         FOREST_REPORTER.report error
         FOREST_LOGGER.error "Association Dissociate error: #{error}\n#{format_stacktrace(error)}"

--- a/app/controllers/forest_liana/associations_controller.rb
+++ b/app/controllers/forest_liana/associations_controller.rb
@@ -15,10 +15,13 @@ module ForestLiana
     end
 
     def index
+      # Parity with agent-nodejs's list-related route: browse/export on the foreign collection.
+      # Authorized outside the begin, like update/associate/dissociate, so a denial reaches
+      # ApplicationController's rescue_from and keeps its name/data instead of falling into the
+      # generic ExpectedError rescue below.
+      action = request.format == 'csv' ? 'export' : 'browse'
+      forest_authorize!(action, forest_user, @association.klass)
       begin
-        # Parity with agent-nodejs's list-related route: browse/export on the foreign collection.
-        action = request.format == 'csv' ? 'export' : 'browse'
-        forest_authorize!(action, forest_user, @association.klass)
         getter = HasManyGetter.new(@resource, @association, params, forest_user)
         getter.perform
 
@@ -60,8 +63,9 @@ module ForestLiana
       #         through and dereferencing a nil @association, which surfaced as
       #         a double-render / 500 rather than the intended 404.
       return if performed?
+      # Authorized outside the begin, like index above, so a denial keeps its name/data.
+      forest_authorize!('browse', forest_user, @association.klass)
       begin
-        forest_authorize!('browse', forest_user, @association.klass)
         getter = HasManyGetter.new(@resource, @association, params, forest_user)
         getter.count
 

--- a/app/controllers/forest_liana/associations_controller.rb
+++ b/app/controllers/forest_liana/associations_controller.rb
@@ -94,6 +94,7 @@ module ForestLiana
         # for a belongsTo.
         edit_subject = @association.macro == :has_one ? @association.klass : @resource
         forest_authorize!('edit', forest_user, edit_subject)
+        forest_authorize!('delete', forest_user, @association.klass) if BelongsToUpdater.replaces_destructively?(@association)
         updater = BelongsToUpdater.new(@resource, @association, params)
         updater.perform
 
@@ -119,7 +120,7 @@ module ForestLiana
 
     def associate
       begin
-        forest_authorize!('edit', forest_user, @association.klass)
+        forest_authorize!('edit', forest_user, HasManyAssociator.authorize_target(@association))
         associator = HasManyAssociator.new(@resource, @association, params)
         associator.perform
 

--- a/app/controllers/forest_liana/associations_controller.rb
+++ b/app/controllers/forest_liana/associations_controller.rb
@@ -23,7 +23,8 @@ module ForestLiana
           format.json { render_jsonapi(getter) }
           format.csv { render_csv(getter, @association.klass) }
         end
-      rescue ForestLiana::Ability::Exceptions::UnauthorizedFieldsError => error
+      rescue ForestLiana::Ability::Exceptions::UnauthorizedFieldsError,
+             ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError => error
         # A CSV request already has its response Content-Type/Content-Disposition set by the
         # respond_to format match before this rescue ever runs — force JSON back, or the client
         # downloads a ".csv" file whose content is this JSON error.
@@ -61,6 +62,21 @@ module ForestLiana
         getter.count
 
         render serializer: nil, json: { count: getter.records_count }
+      rescue ForestLiana::Ability::Exceptions::UnauthorizedFieldsError,
+             ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError => error
+        render(serializer: nil, json: { errors: [{
+          status: error.error_code,
+          detail: error.message,
+          name: error.name,
+          data: error.data
+        }] }, status: error.status)
+      rescue ForestLiana::Errors::ExpectedError => error
+        error.display_error
+        error_data = ForestAdmin::JSONAPI::Serializer.serialize_errors([{
+          status: error.error_code,
+          detail: error.message
+        }])
+        render(serializer: nil, json: error_data, status: error.status)
       rescue => error
         FOREST_REPORTER.report error
         FOREST_LOGGER.error "Association Index Count error: #{error}\n#{format_stacktrace(error)}"

--- a/app/controllers/forest_liana/associations_controller.rb
+++ b/app/controllers/forest_liana/associations_controller.rb
@@ -16,9 +16,7 @@ module ForestLiana
 
     def index
       begin
-        # Unlike ResourcesController#index, nothing upstream gates this route on any permission —
-        # matches agent-nodejs's list-related route, which checks browse (or export for CSV) on
-        # the foreign collection, not the parent, before listing it.
+        # Parity with agent-nodejs's list-related route: browse/export on the foreign collection.
         action = request.format == 'csv' ? 'export' : 'browse'
         forest_authorize!(action, forest_user, @association.klass)
         getter = HasManyGetter.new(@resource, @association, params, forest_user)
@@ -92,6 +90,10 @@ module ForestLiana
 
     def update
       begin
+        # BelongsToUpdater's writer saves the FK on the target for a has_one, on @resource only
+        # for a belongsTo.
+        edit_subject = @association.macro == :has_one ? @association.klass : @resource
+        forest_authorize!('edit', forest_user, edit_subject)
         updater = BelongsToUpdater.new(@resource, @association, params)
         updater.perform
 
@@ -101,6 +103,13 @@ module ForestLiana
         else
           head :no_content
         end
+      rescue ForestLiana::Errors::ExpectedError => error
+        error.display_error
+        error_data = ForestAdmin::JSONAPI::Serializer.serialize_errors([{
+          status: error.error_code,
+          detail: error.message
+        }])
+        render(serializer: nil, json: error_data, status: error.status)
       rescue => error
         FOREST_REPORTER.report error
         FOREST_LOGGER.error "Association Update error: #{error}\n#{format_stacktrace(error)}"
@@ -110,10 +119,18 @@ module ForestLiana
 
     def associate
       begin
+        forest_authorize!('edit', forest_user, @association.klass)
         associator = HasManyAssociator.new(@resource, @association, params)
         associator.perform
 
         head :no_content
+      rescue ForestLiana::Errors::ExpectedError => error
+        error.display_error
+        error_data = ForestAdmin::JSONAPI::Serializer.serialize_errors([{
+          status: error.error_code,
+          detail: error.message
+        }])
+        render(serializer: nil, json: error_data, status: error.status)
       rescue => error
         FOREST_REPORTER.report error
         FOREST_LOGGER.error "Association Associate error: #{error}\n#{format_stacktrace(error)}"
@@ -123,6 +140,8 @@ module ForestLiana
 
     def dissociate
       begin
+        action = (params[:delete].to_s == 'true' || HasManyDissociator.destroys_on_unlink?(@association)) ? 'delete' : 'edit'
+        forest_authorize!(action, forest_user, @association.klass)
         dissociator = HasManyDissociator.new(@resource, @association, params, forest_user)
         dissociator.perform
 

--- a/app/controllers/forest_liana/associations_controller.rb
+++ b/app/controllers/forest_liana/associations_controller.rb
@@ -89,12 +89,13 @@ module ForestLiana
     end
 
     def update
+      # BelongsToUpdater's writer saves the FK on the target for a has_one, on @resource only
+      # for a belongsTo. Authorized outside the begin, like ResourcesController's own actions, so
+      # a denial reaches ApplicationController's rescue_from and keeps its name/data.
+      edit_subject = @association.macro == :has_one ? @association.klass : @resource
+      forest_authorize!('edit', forest_user, edit_subject)
+      forest_authorize!('delete', forest_user, @association.klass) if BelongsToUpdater.replaces_destructively?(@association)
       begin
-        # BelongsToUpdater's writer saves the FK on the target for a has_one, on @resource only
-        # for a belongsTo.
-        edit_subject = @association.macro == :has_one ? @association.klass : @resource
-        forest_authorize!('edit', forest_user, edit_subject)
-        forest_authorize!('delete', forest_user, @association.klass) if BelongsToUpdater.replaces_destructively?(@association)
         updater = BelongsToUpdater.new(@resource, @association, params)
         updater.perform
 
@@ -119,8 +120,8 @@ module ForestLiana
     end
 
     def associate
+      forest_authorize!('edit', forest_user, HasManyAssociator.authorize_target(@association))
       begin
-        forest_authorize!('edit', forest_user, HasManyAssociator.authorize_target(@association))
         associator = HasManyAssociator.new(@resource, @association, params)
         associator.perform
 
@@ -140,16 +141,16 @@ module ForestLiana
     end
 
     def dissociate
+      if params[:delete].to_s == 'true'
+        # Explicit delete destroys the far record directly, regardless of association shape.
+        action = 'delete'
+        authorize_target = @association.klass
+      else
+        action = HasManyDissociator.destroys_on_unlink?(@association) ? 'delete' : 'edit'
+        authorize_target = HasManyDissociator.destroy_target(@association)
+      end
+      forest_authorize!(action, forest_user, authorize_target)
       begin
-        if params[:delete].to_s == 'true'
-          # Explicit delete destroys the far record directly, regardless of association shape.
-          action = 'delete'
-          authorize_target = @association.klass
-        else
-          action = HasManyDissociator.destroys_on_unlink?(@association) ? 'delete' : 'edit'
-          authorize_target = HasManyDissociator.destroy_target(@association)
-        end
-        forest_authorize!(action, forest_user, authorize_target)
         dissociator = HasManyDissociator.new(@resource, @association, params, forest_user)
         dissociator.perform
 

--- a/app/controllers/forest_liana/associations_controller.rb
+++ b/app/controllers/forest_liana/associations_controller.rb
@@ -16,6 +16,11 @@ module ForestLiana
 
     def index
       begin
+        # Unlike ResourcesController#index, nothing upstream gates this route on any permission —
+        # matches agent-nodejs's list-related route, which checks browse (or export for CSV) on
+        # the foreign collection, not the parent, before listing it.
+        action = request.format == 'csv' ? 'export' : 'browse'
+        forest_authorize!(action, forest_user, @association.klass)
         getter = HasManyGetter.new(@resource, @association, params, forest_user)
         getter.perform
 
@@ -58,6 +63,7 @@ module ForestLiana
       #         a double-render / 500 rather than the intended 404.
       return if performed?
       begin
+        forest_authorize!('browse', forest_user, @association.klass)
         getter = HasManyGetter.new(@resource, @association, params, forest_user)
         getter.count
 

--- a/app/controllers/forest_liana/associations_controller.rb
+++ b/app/controllers/forest_liana/associations_controller.rb
@@ -140,8 +140,15 @@ module ForestLiana
 
     def dissociate
       begin
-        action = (params[:delete].to_s == 'true' || HasManyDissociator.destroys_on_unlink?(@association)) ? 'delete' : 'edit'
-        forest_authorize!(action, forest_user, @association.klass)
+        if params[:delete].to_s == 'true'
+          # Explicit delete destroys the far record directly, regardless of association shape.
+          action = 'delete'
+          authorize_target = @association.klass
+        else
+          action = HasManyDissociator.destroys_on_unlink?(@association) ? 'delete' : 'edit'
+          authorize_target = HasManyDissociator.destroy_target(@association)
+        end
+        forest_authorize!(action, forest_user, authorize_target)
         dissociator = HasManyDissociator.new(@resource, @association, params, forest_user)
         dissociator.perform
 

--- a/app/controllers/forest_liana/resources_controller.rb
+++ b/app/controllers/forest_liana/resources_controller.rb
@@ -31,7 +31,8 @@ module ForestLiana
       rescue ForestLiana::Errors::LiveQueryError => error
         render json: { errors: [{ status: 422, detail: error.message }] },
           status: :unprocessable_entity, serializer: nil
-      rescue ForestLiana::Ability::Exceptions::UnauthorizedFieldsError => error
+      rescue ForestLiana::Ability::Exceptions::UnauthorizedFieldsError,
+             ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError => error
         # A CSV request already has its response Content-Type/Content-Disposition set by the
         # respond_to format match before this rescue ever runs — force JSON back, or the client
         # downloads a ".csv" file whose content is this JSON error.

--- a/app/controllers/forest_liana/resources_controller.rb
+++ b/app/controllers/forest_liana/resources_controller.rb
@@ -182,6 +182,13 @@ module ForestLiana
         end
       rescue ActiveRecord::RecordNotDestroyed => error
         render json: { errors: [{ status: :bad_request, detail: error.message }] }, status: :bad_request
+      rescue ForestLiana::Errors::ExpectedError => error
+        error.display_error
+        error_data = ForestAdmin::JSONAPI::Serializer.serialize_errors([{
+          status: error.error_code,
+          detail: error.message
+        }])
+        render(serializer: nil, json: error_data, status: error.status)
       rescue => error
         FOREST_REPORTER.report error
         FOREST_LOGGER.error "Records Destroy error: #{error}\n#{format_stacktrace(error)}"

--- a/app/controllers/forest_liana/resources_controller.rb
+++ b/app/controllers/forest_liana/resources_controller.rb
@@ -69,6 +69,14 @@ module ForestLiana
       rescue ForestLiana::Errors::LiveQueryError => error
         render json: { errors: [{ status: 422, detail: error.message }] },
           status: :unprocessable_entity, serializer: nil
+      rescue ForestLiana::Ability::Exceptions::UnauthorizedFieldsError,
+             ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError => error
+        render(serializer: nil, json: { errors: [{
+          status: error.error_code,
+          detail: error.message,
+          name: error.name,
+          data: error.data
+        }] }, status: error.status)
       rescue ForestLiana::Errors::ExpectedError => error
         error.display_error
         error_data = ForestAdmin::JSONAPI::Serializer.serialize_errors([{

--- a/app/services/forest_liana/ability/exceptions/unauthorized_query_field_error.rb
+++ b/app/services/forest_liana/ability/exceptions/unauthorized_query_field_error.rb
@@ -1,0 +1,21 @@
+module ForestLiana
+  module Ability
+    module Exceptions
+      class UnauthorizedQueryFieldError < ForestLiana::Errors::ExpectedError
+        attr_reader :data
+
+        def initialize(action, path, collections, backtrace = nil)
+          @data = { action: action, field: path }
+
+          super(
+            403,
+            :forbidden,
+            "You cannot #{action} '#{path}': you are not allowed to read #{FieldPath.leaf_label(collections)}.",
+            'UnauthorizedQueryFieldError',
+            backtrace,
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/forest_liana/ability/permission.rb
+++ b/app/services/forest_liana/ability/permission.rb
@@ -308,12 +308,14 @@ module ForestLiana
       # guard raises its own, already-pinned message for it, and the query never runs either way.
       # Sort has no such downstream validator, so its own path is resolved without this rescue.
       #
-      # FiltersParser only ever reads one association hop (+assoc:field+); a deeper path such as
-      # +island:location:name+ still resolves here (FieldPath recurses as far as the reflections
-      # go), but the parser would reject it as a malformed/unknown field regardless of permission,
-      # so checking a collection the query itself can never reach is left unchecked too.
+      # FiltersParser#parse_field_name only ever reads one association hop (+assoc:field+) — it
+      # builds the quoted field from segment 1 but validates existence against the *last* segment,
+      # so a deeper path such as +island:name:id+ (a real column at 1, a real column at -1) slips
+      # its own validation and runs as a live filter on segment 1's table. Truncating to the same
+      # two segments the parser actually reads — mirroring +sort_field_path+ below — checks
+      # permission on the collection the query really touches, instead of skipping it outright.
       def query_usage(action, root_model, path)
-        return nil if path.count(':') > 1
+        path = path.split(':').first(2).join(':')
 
         { action: action, path: path, collections: resolve_owner(root_model, path) }
       rescue ForestLiana::Errors::HTTP422Error

--- a/app/services/forest_liana/ability/permission.rb
+++ b/app/services/forest_liana/ability/permission.rb
@@ -139,6 +139,28 @@ module ForestLiana
         redacted
       end
 
+      # Refused rather than redacted, unlike +redact_fields+: dropping a filter condition widens
+      # the result set, and dropping a sort clause silently reorders it. +root_model+ is pinned
+      # readable — +browse+/+read+ already gate it upstream — so it is never itself a refusal.
+      def assert_can_read_query_fields(user, root_model, filter_paths: [], sort_paths: [])
+        root_name = ForestLiana.name_for(root_model)
+
+        usages = filter_paths.filter_map { |path| query_usage('filter on', root_model, path) } +
+                 sort_paths.map { |path| { action: 'sort on', path: path, collections: resolve_owner(root_model, path) } }
+
+        return if usages.empty?
+
+        allowed = read_permissions(user, usages.flat_map { |usage| usage[:collections] }).merge(root_name => true)
+        readable_collection_names = allowed.filter_map { |name, ok| name if ok }
+
+        denied = usages.find { |usage| !FieldPath.readable_leaves?(usage[:collections], readable_collection_names) }
+        return unless denied
+
+        raise ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError.new(
+          denied[:action], denied[:path], denied[:collections]
+        )
+      end
+
       def is_chart_authorized?(user, parameters)
         parameters = parameters.to_h
         parameters.delete('timezone')
@@ -277,6 +299,15 @@ module ForestLiana
         forest_collection = ForestLiana.apimap.find { |collection| collection.name.to_s == ForestLiana.name_for(model) }
 
         forest_collection&.fields_smart_belongs_to&.find { |field| field[:field].to_s == field_name }
+      end
+
+      # An unresolvable filter path is left unchecked here: the parser that runs right after this
+      # guard raises its own, already-pinned message for it, and the query never runs either way.
+      # Sort has no such downstream validator, so its own path is resolved without this rescue.
+      def query_usage(action, root_model, path)
+        { action: action, path: path, collections: resolve_owner(root_model, path) }
+      rescue ForestLiana::Errors::HTTP422Error
+        nil
       end
     end
   end

--- a/app/services/forest_liana/ability/permission.rb
+++ b/app/services/forest_liana/ability/permission.rb
@@ -150,7 +150,10 @@ module ForestLiana
 
         return if usages.empty?
 
-        allowed = read_permissions(user, usages.flat_map { |usage| usage[:collections] }).merge(root_name => true)
+        # root_name is pinned readable above already; leaving it in would make a denial for it
+        # (the only way it could ever appear in usages: an owner resolves back to the root itself)
+        # trigger read_permissions' retry-on-denial refetch on every single request.
+        allowed = read_permissions(user, usages.flat_map { |usage| usage[:collections] }.uniq - [root_name]).merge(root_name => true)
         readable_collection_names = allowed.filter_map { |name, ok| name if ok }
 
         denied = usages.find { |usage| !FieldPath.readable_leaves?(usage[:collections], readable_collection_names) }

--- a/app/services/forest_liana/ability/permission.rb
+++ b/app/services/forest_liana/ability/permission.rb
@@ -307,7 +307,14 @@ module ForestLiana
       # An unresolvable filter path is left unchecked here: the parser that runs right after this
       # guard raises its own, already-pinned message for it, and the query never runs either way.
       # Sort has no such downstream validator, so its own path is resolved without this rescue.
+      #
+      # FiltersParser only ever reads one association hop (+assoc:field+); a deeper path such as
+      # +island:location:name+ still resolves here (FieldPath recurses as far as the reflections
+      # go), but the parser would reject it as a malformed/unknown field regardless of permission,
+      # so checking a collection the query itself can never reach is left unchecked too.
       def query_usage(action, root_model, path)
+        return nil if path.count(':') > 1
+
         { action: action, path: path, collections: resolve_owner(root_model, path) }
       rescue ForestLiana::Errors::HTTP422Error
         nil

--- a/app/services/forest_liana/ability/permission.rb
+++ b/app/services/forest_liana/ability/permission.rb
@@ -145,8 +145,8 @@ module ForestLiana
       def assert_can_read_query_fields(user, root_model, filter_paths: [], sort_paths: [])
         root_name = ForestLiana.name_for(root_model)
 
-        usages = filter_paths.filter_map { |path| query_usage('filter on', root_model, path) } +
-                 sort_paths.map { |path| { action: 'sort on', path: path, collections: resolve_owner(root_model, path) } }
+        usages = filter_paths.map { |path| query_usage('filter on', root_model, path) } +
+                 sort_paths.map { |path| { action: 'sort on', path: path, collections: query_target_collections(root_model, path) } }
 
         return if usages.empty?
 
@@ -304,22 +304,17 @@ module ForestLiana
         forest_collection&.fields_smart_belongs_to&.find { |field| field[:field].to_s == field_name }
       end
 
-      # An unresolvable filter path is left unchecked here: the parser that runs right after this
-      # guard raises its own, already-pinned message for it, and the query never runs either way.
-      # Sort has no such downstream validator, so its own path is resolved without this rescue.
-      #
-      # FiltersParser#parse_field_name only ever reads one association hop (+assoc:field+) — it
-      # builds the quoted field from segment 1 but validates existence against the *last* segment,
-      # so a deeper path such as +island:name:id+ (a real column at 1, a real column at -1) slips
-      # its own validation and runs as a live filter on segment 1's table. Truncating to the same
-      # two segments the parser actually reads — mirroring +sort_field_path+ below — checks
-      # permission on the collection the query really touches, instead of skipping it outright.
-      def query_usage(action, root_model, path)
-        path = path.split(':').first(2).join(':')
+      # Both FiltersParser and sort_query/detect_reference treat segment 2 as a plain column of
+      # segment 1's collection, never recursing further — resolving the full path would recurse
+      # past segment 1 whenever segment 2 also happens to name a real association, checking a
+      # collection neither a filter nor a sort ever actually reaches. partition (not split) so an
+      # empty or colon-only path resolves to '' (the root, pinned readable) instead of nil.
+      def query_target_collections(root_model, path)
+        resolve_owner(root_model, path.partition(':').first)
+      end
 
-        { action: action, path: path, collections: resolve_owner(root_model, path) }
-      rescue ForestLiana::Errors::HTTP422Error
-        nil
+      def query_usage(action, root_model, path)
+        { action: action, path: path, collections: query_target_collections(root_model, path) }
       end
     end
   end

--- a/app/services/forest_liana/belongs_to_updater.rb
+++ b/app/services/forest_liana/belongs_to_updater.rb
@@ -6,8 +6,10 @@ module ForestLiana
 
     # Replacing a has_one target only destroys the previous one when the reflection's own
     # dependent option says so (:destroy or :delete) — the default just nullifies its FK.
+    # Rails ignores dependent: on a has_one :through, so that option is never destructive there.
     def self.replaces_destructively?(association)
-      association.macro == :has_one && %i[destroy delete].include?(association.options[:dependent])
+      association.macro == :has_one && !association.options[:through] &&
+        %i[destroy delete].include?(association.options[:dependent])
     end
 
     def initialize(resource, association, params)

--- a/app/services/forest_liana/belongs_to_updater.rb
+++ b/app/services/forest_liana/belongs_to_updater.rb
@@ -4,6 +4,12 @@ module ForestLiana
 
     attr_accessor :errors
 
+    # Replacing a has_one target only destroys the previous one when the reflection's own
+    # dependent option says so (:destroy or :delete) — the default just nullifies its FK.
+    def self.replaces_destructively?(association)
+      association.macro == :has_one && %i[destroy delete].include?(association.options[:dependent])
+    end
+
     def initialize(resource, association, params)
       @resource = resource
       @association = association

--- a/app/services/forest_liana/filters_parser.rb
+++ b/app/services/forest_liana/filters_parser.rb
@@ -3,12 +3,14 @@ module ForestLiana
     AGGREGATOR_OPERATOR = %w(and or).freeze
 
     # The `field` of every leaf in a filter tree, however deeply nested — the same tree
-    # `apply_filters` will walk, read rather than re-derived.
+    # `apply_filters` will walk, read rather than re-derived. A leaf with no valid `field` is left
+    # out rather than forwarded: `ensure_valid_condition` raises its own 422 for it right after
+    # this is read, and a non-String value would otherwise reach FieldPath, which expects one.
     def self.field_paths(filter)
       return [] if filter.nil?
       return filter['conditions'].flat_map { |condition| field_paths(condition) } if filter['aggregator']
 
-      [filter['field']]
+      filter['field'].is_a?(String) ? [filter['field']] : []
     end
 
     def initialize(filters, resource, timezone, params = nil)

--- a/app/services/forest_liana/filters_parser.rb
+++ b/app/services/forest_liana/filters_parser.rb
@@ -2,6 +2,15 @@ module ForestLiana
   class FiltersParser
     AGGREGATOR_OPERATOR = %w(and or).freeze
 
+    # The `field` of every leaf in a filter tree, however deeply nested — the same tree
+    # `apply_filters` will walk, read rather than re-derived.
+    def self.field_paths(filter)
+      return [] if filter.nil?
+      return filter['conditions'].flat_map { |condition| field_paths(condition) } if filter['aggregator']
+
+      [filter['field']]
+    end
+
     def initialize(filters, resource, timezone, params = nil)
       @filters = filters
       @params = params

--- a/app/services/forest_liana/filters_parser.rb
+++ b/app/services/forest_liana/filters_parser.rb
@@ -8,7 +8,10 @@ module ForestLiana
     # this is read, and a non-String value would otherwise reach FieldPath, which expects one.
     def self.field_paths(filter)
       return [] if filter.nil?
-      return filter['conditions'].flat_map { |condition| field_paths(condition) } if filter['aggregator']
+      if filter['aggregator']
+        return [] unless filter['conditions'].is_a?(Array)
+        return filter['conditions'].flat_map { |condition| field_paths(condition) }
+      end
 
       filter['field'].is_a?(String) ? [filter['field']] : []
     end

--- a/app/services/forest_liana/filters_parser.rb
+++ b/app/services/forest_liana/filters_parser.rb
@@ -3,11 +3,13 @@ module ForestLiana
     AGGREGATOR_OPERATOR = %w(and or).freeze
 
     # The `field` of every leaf in a filter tree, however deeply nested — the same tree
-    # `apply_filters` will walk, read rather than re-derived. A leaf with no valid `field` is left
-    # out rather than forwarded: `ensure_valid_condition` raises its own 422 for it right after
-    # this is read, and a non-String value would otherwise reach FieldPath, which expects one.
+    # `apply_filters` will walk, read rather than re-derived. A non-Hash node (a top-level
+    # `filters=[]`, say) is left out rather than crashing on `node['aggregator']`: it still reaches
+    # `ensure_valid_aggregation`'s own 422 once `apply_filters` runs. A leaf with no valid `field`
+    # is likewise left out: `ensure_valid_condition` raises its own 422 for it right after this is
+    # read, and a non-String value would otherwise reach FieldPath, which expects one.
     def self.field_paths(filter)
-      return [] if filter.nil?
+      return [] unless filter.is_a?(Hash)
       if filter['aggregator']
         return [] unless filter['conditions'].is_a?(Array)
         return filter['conditions'].flat_map { |condition| field_paths(condition) }

--- a/app/services/forest_liana/filters_parser.rb
+++ b/app/services/forest_liana/filters_parser.rb
@@ -308,6 +308,12 @@ module ForestLiana
     def ensure_valid_aggregation(node)
       raise ForestLiana::Errors::HTTP422Error.new('Filters cannot be a raw value') unless node.is_a?(Hash)
       raise_empty_condition_in_filter_error if node.empty?
+      # A Hash `conditions` degrades into this same error by accident, via Hash#each yielding
+      # [key, value] pairs one level down — every other non-Array shape (nil in particular)
+      # would otherwise crash uncaught instead of answering this 422.
+      if node['aggregator'] && !node['conditions'].is_a?(Array)
+        raise ForestLiana::Errors::HTTP422Error.new('Filters cannot be a raw value')
+      end
     end
 
     def ensure_valid_condition(condition)

--- a/app/services/forest_liana/has_many_associator.rb
+++ b/app/services/forest_liana/has_many_associator.rb
@@ -3,9 +3,12 @@ module ForestLiana
     include ForestLiana::RecordFindable
 
     # A through association's `<<` creates a row in the join collection, never touching the far
-    # one — the far record found by id already exists and is left untouched.
+    # one — the far record found by id already exists and is left untouched. Falls back to the
+    # far collection when the join model is hidden from the schema (ForestLiana.excluded_models),
+    # same reasoning as HasManyDissociator.destroy_target.
     def self.authorize_target(association)
-      association.options[:through] ? association.through_reflection.klass : association.klass
+      join = association.options[:through] && association.through_reflection.klass
+      join && SchemaUtils.model_included?(join) ? join : association.klass
     end
 
     def initialize(resource, association, params)

--- a/app/services/forest_liana/has_many_associator.rb
+++ b/app/services/forest_liana/has_many_associator.rb
@@ -2,6 +2,12 @@ module ForestLiana
   class HasManyAssociator
     include ForestLiana::RecordFindable
 
+    # A through association's `<<` creates a row in the join collection, never touching the far
+    # one — the far record found by id already exists and is left untouched.
+    def self.authorize_target(association)
+      association.options[:through] ? association.through_reflection.klass : association.klass
+    end
+
     def initialize(resource, association, params)
       @resource = resource
       @association = association

--- a/app/services/forest_liana/has_many_dissociator.rb
+++ b/app/services/forest_liana/has_many_dissociator.rb
@@ -2,6 +2,12 @@ module ForestLiana
   class HasManyDissociator
     include ForestLiana::RecordFindable
 
+    # A plain unlink still destroys the associated record when the reflection itself says so —
+    # the delete param passed by the caller isn't the only thing that decides it.
+    def self.destroys_on_unlink?(association)
+      association.macro == :has_many && %i[destroy delete_all].include?(association.options[:dependent])
+    end
+
     def initialize(resource, association, params, forest_user)
       @resource = resource
       @association = association

--- a/app/services/forest_liana/has_many_dissociator.rb
+++ b/app/services/forest_liana/has_many_dissociator.rb
@@ -2,10 +2,19 @@ module ForestLiana
   class HasManyDissociator
     include ForestLiana::RecordFindable
 
-    # A plain unlink still destroys the associated record when the reflection itself says so —
-    # the delete param passed by the caller isn't the only thing that decides it.
+    # A through association's plain unlink never touches the far collection at all — it destroys
+    # (or, dependent: :nullify, just detaches) a row of the join collection instead. A plain
+    # has_many only destroys the far record when its own dependent option says so.
     def self.destroys_on_unlink?(association)
+      return association.options[:dependent] != :nullify if association.options[:through]
+
       association.macro == :has_many && %i[destroy delete_all].include?(association.options[:dependent])
+    end
+
+    # The collection a plain unlink actually writes to: the join collection for a through
+    # association (see destroys_on_unlink?), the far collection otherwise.
+    def self.destroy_target(association)
+      association.options[:through] ? association.through_reflection.klass : association.klass
     end
 
     def initialize(resource, association, params, forest_user)

--- a/app/services/forest_liana/has_many_dissociator.rb
+++ b/app/services/forest_liana/has_many_dissociator.rb
@@ -12,9 +12,13 @@ module ForestLiana
     end
 
     # The collection a plain unlink actually writes to: the join collection for a through
-    # association (see destroys_on_unlink?), the far collection otherwise.
+    # association (see destroys_on_unlink?), the far collection otherwise. Falls back to the far
+    # collection when the join model is hidden from the schema (ForestLiana.excluded_models, the
+    # normal way to keep a join table out of the UI) — the alternative is a permission check
+    # against a collection that doesn't exist, which breaks the route rather than gating it.
     def self.destroy_target(association)
-      association.options[:through] ? association.through_reflection.klass : association.klass
+      join = association.options[:through] && association.through_reflection.klass
+      join && SchemaUtils.model_included?(join) ? join : association.klass
     end
 
     def initialize(resource, association, params, forest_user)

--- a/app/services/forest_liana/has_many_getter.rb
+++ b/app/services/forest_liana/has_many_getter.rb
@@ -10,6 +10,7 @@ module ForestLiana
       @resource = resource
       @association = association
       @params = params
+      @user = forest_user
       @collection_name = ForestLiana.name_for(model_association)
       @field_names_requested = field_names_requested
       @collection = get_collection(@collection_name)
@@ -24,6 +25,7 @@ module ForestLiana
     #         Only the relations optimize_record_loading actually joins can be projected — the
     #         display-only ones are preloaded on purpose, and come back whole.
     def perform
+      @search_query_builder.assert_sort_readable!(@user, model_association)
       return @records unless project?
 
       polymorphic_associations, preload_loads = analyze_associations(model_association)

--- a/app/services/forest_liana/has_many_getter.rb
+++ b/app/services/forest_liana/has_many_getter.rb
@@ -20,12 +20,16 @@ module ForestLiana
       prepare_query()
     end
 
+    def assert_sort_readable!
+      @search_query_builder.assert_sort_readable!(@user, model_association)
+    end
+
     # NOTICE: The projection is applied here and not in prepare_query: count builds its own
     #         getter and never calls perform, and query_for_batch keeps the unprojected query.
     #         Only the relations optimize_record_loading actually joins can be projected — the
     #         display-only ones are preloaded on purpose, and come back whole.
     def perform
-      @search_query_builder.assert_sort_readable!(@user, model_association)
+      assert_sort_readable!
       return @records unless project?
 
       polymorphic_associations, preload_loads = analyze_associations(model_association)

--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -31,6 +31,7 @@ module ForestLiana
     end
 
     def perform
+      @search_query_builder.assert_sort_readable!(@user, @resource)
       polymorphic_association, preload_loads = analyze_associations(@resource)
       includes = @includes.uniq - polymorphic_association - preload_loads - @optional_includes
       has_smart_fields = Array(@params.dig(:fields, @collection_name)&.split(',')).any? do |field|

--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -30,8 +30,12 @@ module ForestLiana
       filter_excluded_ids(ids, attributes[:all_records_ids_excluded])
     end
 
-    def perform
+    def assert_sort_readable!
       @search_query_builder.assert_sort_readable!(@user, @resource)
+    end
+
+    def perform
+      assert_sort_readable!
       polymorphic_association, preload_loads = analyze_associations(@resource)
       includes = @includes.uniq - polymorphic_association - preload_loads - @optional_includes
       has_smart_fields = Array(@params.dig(:fields, @collection_name)&.split(',')).any? do |field|
@@ -233,12 +237,9 @@ module ForestLiana
     end
 
     # query_for_batch below serves @base_records_for_batch/@records as built by the constructor,
-    # never by #perform — but #perform is the only thing that calls assert_sort_readable!, so
-    # every other caller of get_ids_from_request (destroy_bulk, a select-all dissociate, a smart
-    # action's select-all) would otherwise carry a sort param past this guard entirely. Calling
-    # #perform here for its check alone is safe: it mutates @records for includes/select, which
-    # query_for_batch on ResourcesGetter never reads, and which HasManyGetter's own #perform
-    # leaves untouched either way.
+    # never by #perform — but #perform is the only thing that used to call assert_sort_readable!,
+    # so every other caller of get_ids_from_request (destroy_bulk, a select-all dissociate, a
+    # smart action's select-all) carried a sort param past this guard entirely.
     def self.initialize_resources_getter(attributes, user)
       resources_getter =
         if related_data?(attributes)
@@ -247,7 +248,7 @@ module ForestLiana
           ResourcesGetter.new(SchemaUtils.find_model_from_collection_name(attributes[:collection_name]), attributes, user)
         end
 
-      resources_getter.perform
+      resources_getter.assert_sort_readable!
       resources_getter
     end
 

--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -159,7 +159,10 @@ module ForestLiana
 
       conditions = []
 
-      if filters.is_a?(Hash) && filters.key?('conditions')
+      # A non-Array `conditions` (a malformed aggregator node) is left out rather than iterated:
+      # Hash#each would yield [key, value] pairs, and condition['field'] on one raises a TypeError
+      # instead of letting FiltersParser's own ensure_valid_aggregation answer its usual 422.
+      if filters.is_a?(Hash) && filters['conditions'].is_a?(Array)
         conditions = filters['conditions']
       elsif filters.is_a?(Hash) && filters.key?('field')
         conditions = [filters]

--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -232,12 +232,23 @@ module ForestLiana
       attributes.merge(attributes[:all_records_subset_query].dup.to_unsafe_h)
     end
 
+    # query_for_batch below serves @base_records_for_batch/@records as built by the constructor,
+    # never by #perform — but #perform is the only thing that calls assert_sort_readable!, so
+    # every other caller of get_ids_from_request (destroy_bulk, a select-all dissociate, a smart
+    # action's select-all) would otherwise carry a sort param past this guard entirely. Calling
+    # #perform here for its check alone is safe: it mutates @records for includes/select, which
+    # query_for_batch on ResourcesGetter never reads, and which HasManyGetter's own #perform
+    # leaves untouched either way.
     def self.initialize_resources_getter(attributes, user)
-      if related_data?(attributes)
-        HasManyGetter.new(*related_data_params(attributes, user))
-      else
-        ResourcesGetter.new(SchemaUtils.find_model_from_collection_name(attributes[:collection_name]), attributes, user)
-      end
+      resources_getter =
+        if related_data?(attributes)
+          HasManyGetter.new(*related_data_params(attributes, user))
+        else
+          ResourcesGetter.new(SchemaUtils.find_model_from_collection_name(attributes[:collection_name]), attributes, user)
+        end
+
+      resources_getter.perform
+      resources_getter
     end
 
     def self.related_data?(attributes)

--- a/app/services/forest_liana/scope_manager.rb
+++ b/app/services/forest_liana/scope_manager.rb
@@ -13,6 +13,14 @@ module ForestLiana
 
     def self.append_scope_for_user(existing_filter, user, collection_name, request_context_variables = nil)
       existing_filter = inject_context_variables(existing_filter, user, request_context_variables) if existing_filter
+      append_scope(existing_filter, user, collection_name, request_context_variables)
+    end
+
+    # +existing_filter+ is assumed already context-injected — callers that need to read the
+    # caller's own tree before it merges with the scope (a permission check, say) inject it once
+    # themselves and pass the result here, rather than through +append_scope_for_user+, which
+    # would inject it a second time.
+    def self.append_scope(existing_filter, user, collection_name, request_context_variables = nil)
       scope_filter = get_scope(collection_name, user, request_context_variables)
       filters = [existing_filter, scope_filter].compact
 

--- a/app/services/forest_liana/search_query_builder.rb
+++ b/app/services/forest_liana/search_query_builder.rb
@@ -1,5 +1,7 @@
 module ForestLiana
   class SearchQueryBuilder
+    include ForestLiana::Ability::Permission
+
     REGEX_UUID = /\A[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i
 
     attr_reader :fields_searched
@@ -20,7 +22,9 @@ module ForestLiana
         ForestLiana::QueryHelper.get_tables_associated_to_relations_name(@resource)
       @records = search_param
 
-      filters = ForestLiana::ScopeManager.append_scope_for_user(@params[:filters], @user, @collection.name)
+      caller_filter = @params[:filters].present? ? ForestLiana::ScopeManager.inject_context_variables(@params[:filters], @user) : nil
+      assert_can_read_query_fields(@user, root_model, filter_paths: FiltersParser.field_paths(caller_filter))
+      filters = ForestLiana::ScopeManager.append_scope(caller_filter, @user, @collection.name)
 
       unless filters.blank?
         @records = FiltersParser.new(filters, @records, @params[:timezone]).apply_filters
@@ -175,12 +179,19 @@ module ForestLiana
 
     end
 
+    # Recorded here, checked separately by +assert_sort_readable!+: a count route runs this same
+    # parsing (Rails strips the ORDER BY from the emitted COUNT SQL on its own) but must not refuse
+    # a sort it never actually applies, so the two are split rather than checked inline.
     def sort_query
+      @sort_field_paths = []
+
       if @params[:sort]
         @params[:sort].split(',').each do |field|
           order_detected = detect_sort_order(field)
           order = order_detected.upcase
           field.slice!(0) if order_detected == :desc
+
+          @sort_field_paths << sort_field_path(field)
 
           field = detect_reference(field)
           if field.index('.').nil?
@@ -216,6 +227,10 @@ module ForestLiana
       return (if field[0] == '-' then :desc else :asc end)
     end
 
+    def assert_sort_readable!(user, root_model)
+      assert_can_read_query_fields(user, root_model, sort_paths: @sort_field_paths || [])
+    end
+
     def association_search_condition table_name, column_name
       column_name = format_column_name(table_name, column_name)
       "LOWER(#{column_name}) LIKE :search_value_for_string"
@@ -242,6 +257,22 @@ module ForestLiana
 
       @search.match?(/\A[0-9a-f]+-[0-9a-f]+-[0-9a-f]+-[0-9a-f]+-[0-9a-f]+\z/i) &&
         !REGEX_UUID.match?(@search)
+    end
+
+    # Mirrors detect_reference's own `ref, field = param.split('.')` destructuring: a path deeper
+    # than one relation silently drops everything past the second segment there, so the same
+    # truncation is checked here — checking more than what actually reaches the query would refuse
+    # a request the extra segments never touch.
+    def sort_field_path(field)
+      head, dot, tail = field.partition('.')
+
+      dot.empty? ? head : "#{head}:#{tail.split('.').first}"
+    end
+
+    # `@resource` is either the model class (ResourcesGetter) or an already-scoped
+    # Relation/CollectionProxy (HasManyGetter) — FieldPath needs the class either way.
+    def root_model
+      @resource.respond_to?(:klass) ? @resource.klass : @resource
     end
   end
 end

--- a/app/services/forest_liana/utils/context_variables_injector.rb
+++ b/app/services/forest_liana/utils/context_variables_injector.rb
@@ -40,6 +40,10 @@ module ForestLiana
 
       def self.inject_context_in_filter(filter, context_variables)
         return nil unless filter
+        # A non-Hash filter (a top-level `filters=[]`, say) is left untouched rather than crashing
+        # on filter.key? — FiltersParser's own ensure_valid_aggregation raises its usual 422 for it
+        # once apply_filters runs, same as the non-Array `conditions` case just below.
+        return filter unless filter.is_a?(Hash)
 
         if filter.key? 'aggregator'
           # A non-Array `conditions` is left untouched rather than mapped over (which would

--- a/app/services/forest_liana/utils/context_variables_injector.rb
+++ b/app/services/forest_liana/utils/context_variables_injector.rb
@@ -42,9 +42,13 @@ module ForestLiana
         return nil unless filter
 
         if filter.key? 'aggregator'
+          # A non-Array `conditions` is left untouched rather than mapped over (which would
+          # otherwise iterate Hash#each's own [key, value] pairs) — FiltersParser's own
+          # ensure_valid_aggregation raises its usual 422 for it right after this.
+          conditions = filter['conditions']
           return {
             'aggregator' => filter['aggregator'],
-            'conditions' => filter['conditions'].map { |condition| inject_context_in_filter(condition, context_variables) }
+            'conditions' => conditions.is_a?(Array) ? conditions.map { |condition| inject_context_in_filter(condition, context_variables) } : conditions
           }
         end
 

--- a/spec/dummy/app/models/flag.rb
+++ b/spec/dummy/app/models/flag.rb
@@ -1,0 +1,3 @@
+class Flag < ActiveRecord::Base
+  belongs_to :island, optional: true
+end

--- a/spec/dummy/app/models/island.rb
+++ b/spec/dummy/app/models/island.rb
@@ -4,4 +4,6 @@ class Island < ActiveRecord::Base
   has_many :trees
   has_one :location
   has_one :eponymous_tree, ->(record) { where(name: record.name) }, class_name: 'Tree'
+  has_many :memberships
+  has_many :members, through: :memberships, source: :user
 end

--- a/spec/dummy/app/models/island.rb
+++ b/spec/dummy/app/models/island.rb
@@ -6,4 +6,5 @@ class Island < ActiveRecord::Base
   has_one :eponymous_tree, ->(record) { where(name: record.name) }, class_name: 'Tree'
   has_many :memberships
   has_many :members, through: :memberships, source: :user
+  has_one :flag, dependent: :destroy
 end

--- a/spec/dummy/app/models/membership.rb
+++ b/spec/dummy/app/models/membership.rb
@@ -1,0 +1,4 @@
+class Membership < ActiveRecord::Base
+  belongs_to :island
+  belongs_to :user
+end

--- a/spec/dummy/db/migrate/20260909120000_create_memberships.rb
+++ b/spec/dummy/db/migrate/20260909120000_create_memberships.rb
@@ -1,0 +1,10 @@
+class CreateMemberships < ActiveRecord::Migration[6.0]
+  def change
+    create_table :memberships do |t|
+      t.references :island, null: false
+      t.references :user, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20260909130000_create_flags.rb
+++ b/spec/dummy/db/migrate/20260909130000_create_flags.rb
@@ -1,0 +1,10 @@
+class CreateFlags < ActiveRecord::Migration[6.0]
+  def change
+    create_table :flags do |t|
+      t.references :island
+      t.string :color
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_09_09_120000) do
+ActiveRecord::Schema.define(version: 2026_09_09_130000) do
 
   create_table "addresses", force: :cascade do |t|
     t.string "line1"
@@ -21,6 +21,14 @@ ActiveRecord::Schema.define(version: 2026_09_09_120000) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["addressable_type", "addressable_id"], name: "index_addresses_on_addressable_type_and_addressable_id"
+  end
+
+  create_table "flags", force: :cascade do |t|
+    t.integer "island_id"
+    t.string "color"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["island_id"], name: "index_flags_on_island_id"
   end
 
   create_table "isle", force: :cascade do |t|

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_17_084236) do
+ActiveRecord::Schema.define(version: 2026_09_09_120000) do
 
   create_table "addresses", force: :cascade do |t|
     t.string "line1"
@@ -40,6 +40,15 @@ ActiveRecord::Schema.define(version: 2023_11_17_084236) do
 
   create_table "manufacturers", force: :cascade do |t|
     t.string "name"
+  end
+
+  create_table "memberships", force: :cascade do |t|
+    t.integer "island_id", null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["island_id"], name: "index_memberships_on_island_id"
+    t.index ["user_id"], name: "index_memberships_on_user_id"
   end
 
   create_table "owners", force: :cascade do |t|

--- a/spec/lib/forest_liana/bootstrapper_spec.rb
+++ b/spec/lib/forest_liana/bootstrapper_spec.rb
@@ -27,6 +27,7 @@ module ForestLiana
           Island,
           Location,
           Manufacturer,
+          Membership,
           Owner,
           Product,
           Reference,

--- a/spec/lib/forest_liana/bootstrapper_spec.rb
+++ b/spec/lib/forest_liana/bootstrapper_spec.rb
@@ -24,6 +24,7 @@ module ForestLiana
       let(:expected_application_models) do
         [
           Address,
+          Flag,
           Island,
           Location,
           Manufacturer,

--- a/spec/requests/actions_controller_spec.rb
+++ b/spec/requests/actions_controller_spec.rb
@@ -525,6 +525,10 @@ describe 'Requesting Actions routes', :type => :request  do
     describe 'with scopes' do
       before(:each) do
         allow_any_instance_of(ForestLiana::Ability).to receive(:forest_authorize!) { true }
+        # forest_authorize! is stubbed out above; the field-read-permission checks a select-all
+        # scope resolution runs independently of it must be bypassed the same way, or they hit the
+        # real permissions API with nothing cached to answer from.
+        Rails.cache.write('forest.has_permission', false)
       end
 
       describe 'when record is in scope' do

--- a/spec/requests/associations_spec.rb
+++ b/spec/requests/associations_spec.rb
@@ -443,6 +443,79 @@ describe 'Requesting an association', :type => :request do
     end
   end
 
+  describe 'a has_many :through relation whose join model is excluded from the schema' do
+    around do |example|
+      previous = ForestLiana.excluded_models
+      ForestLiana.excluded_models = ['Membership']
+      example.run
+    ensure
+      ForestLiana.excluded_models = previous
+    end
+
+    after do
+      Membership.destroy_all
+    end
+
+    it 'associate falls back to checking the far collection (User) instead of 409ing' do
+      no_role = { 'roles' => [] }
+      enabled = { 'roles' => [1] }
+      allow_any_instance_of(ForestLiana::Ability::Fetch).to receive(:get_permissions)
+        .with('/liana/v4/permissions/environment').and_return(
+          'collections' => {
+            'Island' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
+            'User' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => no_role, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} }
+          }
+        )
+      Rails.cache.delete('forest.collections')
+
+      params = { data: [{ type: 'User', id: @user.id.to_s }] }
+      post "/forest/Island/#{@island.id}/relationships/members", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(403)
+      expect(Membership.where(island: @island, user: @user)).to be_empty
+    end
+
+    it 'associate still works end to end when the far collection (User) grants edit' do
+      enabled = { 'roles' => [1] }
+      allow_any_instance_of(ForestLiana::Ability::Fetch).to receive(:get_permissions)
+        .with('/liana/v4/permissions/environment').and_return(
+          'collections' => {
+            'Island' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
+            'User' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} }
+          }
+        )
+      Rails.cache.delete('forest.collections')
+
+      params = { data: [{ type: 'User', id: @user.id.to_s }] }
+      post "/forest/Island/#{@island.id}/relationships/members", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(204)
+      expect(Membership.where(island: @island, user: @user)).not_to be_empty
+    end
+
+    # Island.members has no dependent: option, so a plain unlink destroys the join row (see
+    # HasManyDissociator.destroys_on_unlink?) — the action checked here is delete, not edit.
+    it 'dissociate falls back to checking the far collection (User) instead of 409ing' do
+      @membership = Membership.create(island: @island, user: @user)
+      no_role = { 'roles' => [] }
+      enabled = { 'roles' => [1] }
+      allow_any_instance_of(ForestLiana::Ability::Fetch).to receive(:get_permissions)
+        .with('/liana/v4/permissions/environment').and_return(
+          'collections' => {
+            'Island' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
+            'User' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => no_role, 'exportEnabled' => enabled }, 'actions' => {} }
+          }
+        )
+      Rails.cache.delete('forest.collections')
+
+      params = { data: [{ type: 'User', id: @user.id.to_s }] }
+      delete "/forest/Island/#{@island.id}/relationships/members", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(403)
+      expect(Membership.exists?(@membership.id)).to be true
+    end
+  end
+
   describe 'dissociating a has_many :through relation' do
     before do
       @membership = Membership.create(island: @island, user: @user)

--- a/spec/requests/associations_spec.rb
+++ b/spec/requests/associations_spec.rb
@@ -155,4 +155,26 @@ describe 'Requesting an association', :type => :request do
       expect(response.status).to eq(200)
     end
   end
+
+  describe 'select-all dissociate naming a filter on a collection the role cannot read' do
+    it 'refuses with a 403 body instead of a bodiless 500' do
+      params = {
+        data: {
+          attributes: {
+            collection_name: 'Tree',
+            all_records: true,
+            all_records_subset_query: {
+              filters: JSON.generate({ 'field' => 'owner:name', 'operator' => 'equal', 'value' => 'Michel' })
+            }
+          }
+        }
+      }
+
+      delete "/forest/Island/#{@island.id}/relationships/trees", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(403)
+      expect(JSON.parse(response.body)['errors'][0]['detail'])
+        .to eq "You cannot filter on 'owner:name': you are not allowed to read the 'User' collection."
+    end
+  end
 end

--- a/spec/requests/associations_spec.rb
+++ b/spec/requests/associations_spec.rb
@@ -110,4 +110,49 @@ describe 'Requesting an association', :type => :request do
       expect(csv_lines[1]).to eq('1,Lemon Tree')
     end
   end
+
+  describe 'filtering on a column of a collection the role cannot read' do
+    params = {
+      filters: JSON.generate({ 'field' => 'owner:name', 'operator' => 'equal', 'value' => 'Michel' }),
+      page: { 'number' => '1', 'size' => '10' },
+      timezone: 'Europe/Paris'
+    }
+
+    it 'refuses index with a 403 naming the path and the collection' do
+      get "/forest/Island/#{@island.id}/relationships/trees", params: params, headers: headers
+
+      expect(response.status).to eq(403)
+      body = JSON.parse(response.body)
+      expect(body['errors'][0]['detail'])
+        .to eq "You cannot filter on 'owner:name': you are not allowed to read the 'User' collection."
+    end
+
+    # This is the route that had no ExpectedError rescue at all before this guard: anything it
+    # raised surfaced as a bare 500, not the 403 every other route already gave the same denial.
+    it 'refuses count the same way, not with a bodiless 500' do
+      get "/forest/Island/#{@island.id}/relationships/trees/count", params: params, headers: headers
+
+      expect(response.status).to eq(403)
+      expect(JSON.parse(response.body)['errors'][0]['detail'])
+        .to eq "You cannot filter on 'owner:name': you are not allowed to read the 'User' collection."
+    end
+  end
+
+  describe 'sorting on a column of a collection the role cannot read' do
+    params = { sort: '-owner.name', page: { 'number' => '1', 'size' => '10' }, timezone: 'Europe/Paris' }
+
+    it 'refuses index' do
+      get "/forest/Island/#{@island.id}/relationships/trees", params: params, headers: headers
+
+      expect(response.status).to eq(403)
+      expect(JSON.parse(response.body)['errors'][0]['detail'])
+        .to eq "You cannot sort on 'owner:name': you are not allowed to read the 'User' collection."
+    end
+
+    it 'does not refuse count, which never applies the sort' do
+      get "/forest/Island/#{@island.id}/relationships/trees/count", params: params, headers: headers
+
+      expect(response.status).to eq(200)
+    end
+  end
 end

--- a/spec/requests/associations_spec.rb
+++ b/spec/requests/associations_spec.rb
@@ -347,6 +347,102 @@ describe 'Requesting an association', :type => :request do
     end
   end
 
+  describe 'associating a has_many :through relation' do
+    after do
+      Membership.destroy_all
+    end
+
+    # associate on a through association creates a join row (Membership), never touches the far
+    # one (User) — so that's what edit has to be checked on, not User.
+    it 'refuses with a 403, checking edit on the join collection (Membership)' do
+      enabled = { 'roles' => [1] }
+      no_role = { 'roles' => [] }
+      allow_any_instance_of(ForestLiana::Ability::Fetch).to receive(:get_permissions)
+        .with('/liana/v4/permissions/environment').and_return(
+          'collections' => {
+            'Island' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
+            'User' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
+            'Membership' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => no_role, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} }
+          }
+        )
+      Rails.cache.delete('forest.collections')
+
+      params = { data: [{ type: 'User', id: @user.id.to_s }] }
+      post "/forest/Island/#{@island.id}/relationships/members", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(403)
+      expect(Membership.where(island: @island, user: @user)).to be_empty
+    end
+
+    it 'lets an authorized role associate it, creating the join row' do
+      enabled = { 'roles' => [1] }
+      allow_any_instance_of(ForestLiana::Ability::Fetch).to receive(:get_permissions)
+        .with('/liana/v4/permissions/environment').and_return(
+          'collections' => {
+            'Island' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
+            'User' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
+            'Membership' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} }
+          }
+        )
+      Rails.cache.delete('forest.collections')
+
+      params = { data: [{ type: 'User', id: @user.id.to_s }] }
+      post "/forest/Island/#{@island.id}/relationships/members", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(204)
+      expect(Membership.where(island: @island, user: @user)).not_to be_empty
+    end
+  end
+
+  describe 'updating a has_one relation whose reflection destroys the previous target' do
+    after do
+      Flag.destroy_all
+    end
+
+    it 'refuses with a 403, requiring delete in addition to edit on the target (Flag)' do
+      old_flag = Flag.create(island: @island, color: 'red')
+      new_flag = Flag.create(color: 'blue')
+      enabled = { 'roles' => [1] }
+      edit_only = { 'roles' => [1] }
+      no_role = { 'roles' => [] }
+      allow_any_instance_of(ForestLiana::Ability::Fetch).to receive(:get_permissions)
+        .with('/liana/v4/permissions/environment').and_return(
+          'collections' => {
+            'Island' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
+            'Flag' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => edit_only, 'addEnabled' => enabled, 'deleteEnabled' => no_role, 'exportEnabled' => enabled }, 'actions' => {} }
+          }
+        )
+      Rails.cache.delete('forest.collections')
+
+      params = { data: { type: 'Flag', id: new_flag.id.to_s } }
+      put "/forest/Island/#{@island.id}/relationships/flag", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(403)
+      expect(Flag.exists?(old_flag.id)).to be true
+    end
+
+    it 'lets an authorized role replace it, destroying the previous target' do
+      old_flag = Flag.create(island: @island, color: 'red')
+      new_flag = Flag.create(color: 'blue')
+      enabled = { 'roles' => [1] }
+      allow_any_instance_of(ForestLiana::Ability::Fetch).to receive(:get_permissions)
+        .with('/liana/v4/permissions/environment').and_return(
+          'collections' => {
+            'Island' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
+            'Flag' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} }
+          }
+        )
+      Rails.cache.delete('forest.collections')
+
+      params = { data: { type: 'Flag', id: new_flag.id.to_s } }
+      put "/forest/Island/#{@island.id}/relationships/flag", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(204)
+      expect(Flag.exists?(old_flag.id)).to be false
+      expect(@island.reload.flag).to eq(new_flag)
+    end
+  end
+
   describe 'dissociating a has_many :through relation' do
     before do
       @membership = Membership.create(island: @island, user: @user)

--- a/spec/requests/associations_spec.rb
+++ b/spec/requests/associations_spec.rb
@@ -33,6 +33,7 @@ describe 'Requesting an association', :type => :request do
     User.destroy_all
     Tree.destroy_all
     Island.destroy_all
+    Location.destroy_all
   end
 
   token = JWT.encode({
@@ -164,7 +165,10 @@ describe 'Requesting an association', :type => :request do
         .with('/liana/v4/permissions/environment').and_return(
           'collections' => {
             'Island' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
-            'Tree' => { 'collection' => { 'browseEnabled' => disabled, 'readEnabled' => disabled, 'editEnabled' => disabled, 'addEnabled' => disabled, 'deleteEnabled' => disabled, 'exportEnabled' => disabled }, 'actions' => {} }
+            'Tree' => { 'collection' => { 'browseEnabled' => disabled, 'readEnabled' => disabled, 'editEnabled' => disabled, 'addEnabled' => disabled, 'deleteEnabled' => disabled, 'exportEnabled' => disabled }, 'actions' => {} },
+            # Fully enabled so a wrong-collection check (User instead of Tree) shows up as a 204,
+            # not an incidental 409 from an absent collection.
+            'User' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} }
           }
         )
       Rails.cache.delete('forest.collections')
@@ -186,6 +190,138 @@ describe 'Requesting an association', :type => :request do
       get "/forest/Island/#{@island.id}/relationships/trees/count", params: params, headers: headers
 
       expect(response.status).to eq(403)
+    end
+
+    it 'refuses updating a belongsTo with a 403, checking edit on the parent (Tree)' do
+      other_user = User.create(name: 'Other')
+      params = { data: { type: 'User', id: other_user.id.to_s } }
+
+      put "/forest/Tree/#{@tree.id}/relationships/owner", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(403)
+      expect(@tree.reload.owner).to eq(@user)
+    end
+
+    it 'refuses associating with a 403, checking edit on the related collection (Tree)' do
+      other_tree = Tree.create(name: 'Other Tree', owner: @user, cutter: @user)
+      params = { data: [{ type: 'Tree', id: other_tree.id.to_s }] }
+
+      post "/forest/Island/#{@island.id}/relationships/trees", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(403)
+      expect(other_tree.reload.island).to be_nil
+    end
+
+    it 'refuses dissociating with a 403, checking edit (not delete) on the related collection (Tree)' do
+      params = { data: [{ type: 'Tree', id: @tree.id.to_s }] }
+
+      delete "/forest/Island/#{@island.id}/relationships/trees", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(403)
+      expect(@tree.reload.island).to eq(@island)
+    end
+
+    it 'refuses a dissociate-and-delete with a 403, checking delete instead of edit' do
+      params = { delete: 'true', data: [{ type: 'Tree', id: @tree.id.to_s }] }
+
+      delete "/forest/Island/#{@island.id}/relationships/trees", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(403)
+      expect(Tree.exists?(@tree.id)).to be true
+    end
+
+    it 'refuses updating a has_one relation with a 403, checking edit on the target (Location), not the parent (Island)' do
+      other_location = Location.create(coordinates: '9,9')
+      params = { data: { type: 'Location', id: other_location.id.to_s } }
+
+      allow_any_instance_of(ForestLiana::Ability::Fetch).to receive(:get_permissions)
+        .with('/liana/v4/permissions/environment').and_return(
+          'collections' => {
+            'Island' => { 'collection' => { 'browseEnabled' => { 'roles' => [1] }, 'readEnabled' => { 'roles' => [1] }, 'editEnabled' => { 'roles' => [1] }, 'addEnabled' => { 'roles' => [1] }, 'deleteEnabled' => { 'roles' => [1] }, 'exportEnabled' => { 'roles' => [1] } }, 'actions' => {} },
+            'Location' => { 'collection' => { 'browseEnabled' => { 'roles' => [] }, 'readEnabled' => { 'roles' => [] }, 'editEnabled' => { 'roles' => [] }, 'addEnabled' => { 'roles' => [] }, 'deleteEnabled' => { 'roles' => [] }, 'exportEnabled' => { 'roles' => [] } }, 'actions' => {} }
+          }
+        )
+      Rails.cache.delete('forest.collections')
+
+      put "/forest/Island/#{@island.id}/relationships/location", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(403)
+      expect(@island.reload.location).to be_nil
+    end
+  end
+
+  describe 'write actions on a relation, with edit granted but delete denied on the related collection' do
+    before do
+      enabled = { 'roles' => [1] }
+      no_role = { 'roles' => [] }
+      allow_any_instance_of(ForestLiana::Ability::Fetch).to receive(:get_permissions)
+        .with('/liana/v4/permissions/environment').and_return(
+          'collections' => {
+            'Island' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
+            'Tree' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => no_role, 'exportEnabled' => enabled }, 'actions' => {} },
+            'User' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} }
+          }
+        )
+      Rails.cache.delete('forest.collections')
+    end
+
+    # Island.trees has no dependent: option, so a plain unlink only nullifies Tree#island_id.
+    it 'allows a plain dissociate (edit) but refuses the same call with delete: true' do
+      params = { data: [{ type: 'Tree', id: @tree.id.to_s }] }
+      delete "/forest/Island/#{@island.id}/relationships/trees", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(204)
+      expect(@tree.reload.island).to be_nil
+
+      params = { delete: 'true', data: [{ type: 'Tree', id: @tree.id.to_s }] }
+      delete "/forest/Island/#{@island.id}/relationships/trees", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(403)
+      expect(Tree.exists?(@tree.id)).to be true
+    end
+  end
+
+  describe 'write actions on a relation, with the necessary permission granted' do
+    before do
+      enabled = { 'roles' => [1] }
+      allow_any_instance_of(ForestLiana::Ability::Fetch).to receive(:get_permissions)
+        .with('/liana/v4/permissions/environment').and_return(
+          'collections' => {
+            'Island' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
+            'Tree' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
+            'User' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} }
+          }
+        )
+      Rails.cache.delete('forest.collections')
+    end
+
+    it 'lets an authorized role update a belongsTo' do
+      other_user = User.create(name: 'Other')
+      params = { data: { type: 'User', id: other_user.id.to_s } }
+
+      put "/forest/Tree/#{@tree.id}/relationships/owner", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(204)
+      expect(@tree.reload.owner).to eq(other_user)
+    end
+
+    it 'lets an authorized role associate an existing record' do
+      other_tree = Tree.create(name: 'Other Tree', owner: @user, cutter: @user)
+      params = { data: [{ type: 'Tree', id: other_tree.id.to_s }] }
+
+      post "/forest/Island/#{@island.id}/relationships/trees", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(204)
+      expect(other_tree.reload.island).to eq(@island)
+    end
+
+    it 'lets an authorized role dissociate a record' do
+      params = { data: [{ type: 'Tree', id: @tree.id.to_s }] }
+
+      delete "/forest/Island/#{@island.id}/relationships/trees", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(204)
+      expect(@tree.reload.island).to be_nil
     end
   end
 

--- a/spec/requests/associations_spec.rb
+++ b/spec/requests/associations_spec.rb
@@ -352,6 +352,28 @@ describe 'Requesting an association', :type => :request do
     end
   end
 
+  describe 'select-all dissociate sorting on a collection the role cannot read' do
+    it 'refuses with a 403, instead of reordering the ids to dissociate by an unreadable column' do
+      params = {
+        data: {
+          attributes: {
+            collection_name: 'Tree',
+            all_records: true,
+            all_records_subset_query: {
+              sort: '-owner.name'
+            }
+          }
+        }
+      }
+
+      delete "/forest/Island/#{@island.id}/relationships/trees", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(403)
+      expect(JSON.parse(response.body)['errors'][0]['detail'])
+        .to eq "You cannot sort on 'owner:name': you are not allowed to read the 'User' collection."
+    end
+  end
+
   describe 'associating a has_many :through relation' do
     after do
       Membership.destroy_all

--- a/spec/requests/associations_spec.rb
+++ b/spec/requests/associations_spec.rb
@@ -199,6 +199,7 @@ describe 'Requesting an association', :type => :request do
       put "/forest/Tree/#{@tree.id}/relationships/owner", params: JSON.dump(params), headers: headers
 
       expect(response.status).to eq(403)
+      expect(JSON.parse(response.body)['errors'][0]['name']).to eq('AccessDenied')
       expect(@tree.reload.owner).to eq(@user)
     end
 
@@ -209,6 +210,7 @@ describe 'Requesting an association', :type => :request do
       post "/forest/Island/#{@island.id}/relationships/trees", params: JSON.dump(params), headers: headers
 
       expect(response.status).to eq(403)
+      expect(JSON.parse(response.body)['errors'][0]['name']).to eq('AccessDenied')
       expect(other_tree.reload.island).to be_nil
     end
 
@@ -218,6 +220,7 @@ describe 'Requesting an association', :type => :request do
       delete "/forest/Island/#{@island.id}/relationships/trees", params: JSON.dump(params), headers: headers
 
       expect(response.status).to eq(403)
+      expect(JSON.parse(response.body)['errors'][0]['name']).to eq('AccessDenied')
       expect(@tree.reload.island).to eq(@island)
     end
 

--- a/spec/requests/associations_spec.rb
+++ b/spec/requests/associations_spec.rb
@@ -156,6 +156,39 @@ describe 'Requesting an association', :type => :request do
     end
   end
 
+  describe 'listing/counting a relation on a collection the role has zero permission on' do
+    before do
+      enabled = { 'roles' => [1] }
+      disabled = { 'roles' => [] }
+      allow_any_instance_of(ForestLiana::Ability::Fetch).to receive(:get_permissions)
+        .with('/liana/v4/permissions/environment').and_return(
+          'collections' => {
+            'Island' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
+            'Tree' => { 'collection' => { 'browseEnabled' => disabled, 'readEnabled' => disabled, 'editEnabled' => disabled, 'addEnabled' => disabled, 'deleteEnabled' => disabled, 'exportEnabled' => disabled }, 'actions' => {} }
+          }
+        )
+      Rails.cache.delete('forest.collections')
+    end
+
+    it 'refuses index with a 403, rather than serving it unauthorized' do
+      get "/forest/Island/#{@island.id}/relationships/trees",
+          params: { page: { 'number' => '1', 'size' => '10' }, timezone: 'Europe/Paris' }, headers: headers
+
+      expect(response.status).to eq(403)
+      expect(JSON.parse(response.body)['errors'][0]['detail']).to eq "You don't have permission to access this resource"
+    end
+
+    # Without forest_authorize!, a filtered count on a collection the role cannot even browse
+    # answered with the real, filtered row count — letting the filter value be guessed one probe
+    # at a time (0 vs a positive count) without ever touching a field-level read check.
+    it 'refuses count with a 403, instead of a filtered count that leaks whether a value matches' do
+      params = { filters: JSON.generate({ 'field' => 'name', 'operator' => 'equal', 'value' => 'Lemon Tree' }), timezone: 'Europe/Paris' }
+      get "/forest/Island/#{@island.id}/relationships/trees/count", params: params, headers: headers
+
+      expect(response.status).to eq(403)
+    end
+  end
+
   describe 'select-all dissociate naming a filter on a collection the role cannot read' do
     it 'refuses with a 403 body instead of a bodiless 500' do
       params = {

--- a/spec/requests/associations_spec.rb
+++ b/spec/requests/associations_spec.rb
@@ -372,6 +372,33 @@ describe 'Requesting an association', :type => :request do
       expect(JSON.parse(response.body)['errors'][0]['detail'])
         .to eq "You cannot sort on 'owner:name': you are not allowed to read the 'User' collection."
     end
+
+    # Naming parent_collection_id/parent_collection_name/parent_association_name (rather than a
+    # plain collection_name) is what actually routes get_ids_from_request through HasManyGetter —
+    # the branch the sort-readability fix in initialize_resources_getter exists for in the first
+    # place, and the only one of the two get_ids_from_request branches the other example above
+    # doesn't reach.
+    it 'refuses with a 403 through the related/HasManyGetter branch too, not just the plain collection one' do
+      params = {
+        data: {
+          attributes: {
+            parent_collection_id: @island.id.to_s,
+            parent_collection_name: 'Island',
+            parent_association_name: 'trees',
+            all_records: true,
+            all_records_subset_query: {
+              sort: '-owner.name'
+            }
+          }
+        }
+      }
+
+      delete "/forest/Island/#{@island.id}/relationships/trees", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(403)
+      expect(JSON.parse(response.body)['errors'][0]['detail'])
+        .to eq "You cannot sort on 'owner:name': you are not allowed to read the 'User' collection."
+    end
   end
 
   describe 'associating a has_many :through relation' do

--- a/spec/requests/associations_spec.rb
+++ b/spec/requests/associations_spec.rb
@@ -180,6 +180,7 @@ describe 'Requesting an association', :type => :request do
 
       expect(response.status).to eq(403)
       expect(JSON.parse(response.body)['errors'][0]['detail']).to eq "You don't have permission to access this resource"
+      expect(JSON.parse(response.body)['errors'][0]['name']).to eq('AccessDenied')
     end
 
     # Without forest_authorize!, a filtered count on a collection the role cannot even browse
@@ -190,6 +191,7 @@ describe 'Requesting an association', :type => :request do
       get "/forest/Island/#{@island.id}/relationships/trees/count", params: params, headers: headers
 
       expect(response.status).to eq(403)
+      expect(JSON.parse(response.body)['errors'][0]['name']).to eq('AccessDenied')
     end
 
     it 'refuses updating a belongsTo with a 403, checking edit on the parent (Tree)' do

--- a/spec/requests/associations_spec.rb
+++ b/spec/requests/associations_spec.rb
@@ -346,4 +346,56 @@ describe 'Requesting an association', :type => :request do
         .to eq "You cannot filter on 'owner:name': you are not allowed to read the 'User' collection."
     end
   end
+
+  describe 'dissociating a has_many :through relation' do
+    before do
+      @membership = Membership.create(island: @island, user: @user)
+    end
+
+    after do
+      Membership.destroy_all
+    end
+
+    # A plain unlink on a through association only ever touches the join collection (Membership),
+    # never the far one (User) — so that's what edit/delete has to be checked on, not User.
+    it 'refuses a plain dissociate with a 403, checking delete on the join collection (Membership)' do
+      enabled = { 'roles' => [1] }
+      no_role = { 'roles' => [] }
+      allow_any_instance_of(ForestLiana::Ability::Fetch).to receive(:get_permissions)
+        .with('/liana/v4/permissions/environment').and_return(
+          'collections' => {
+            'Island' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
+            'User' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
+            'Membership' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => no_role, 'exportEnabled' => enabled }, 'actions' => {} }
+          }
+        )
+      Rails.cache.delete('forest.collections')
+
+      params = { data: [{ type: 'User', id: @user.id.to_s }] }
+      delete "/forest/Island/#{@island.id}/relationships/members", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(403)
+      expect(Membership.exists?(@membership.id)).to be true
+    end
+
+    it 'lets an authorized role dissociate it, deleting the join row but leaving User intact' do
+      enabled = { 'roles' => [1] }
+      allow_any_instance_of(ForestLiana::Ability::Fetch).to receive(:get_permissions)
+        .with('/liana/v4/permissions/environment').and_return(
+          'collections' => {
+            'Island' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
+            'User' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
+            'Membership' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} }
+          }
+        )
+      Rails.cache.delete('forest.collections')
+
+      params = { data: [{ type: 'User', id: @user.id.to_s }] }
+      delete "/forest/Island/#{@island.id}/relationships/members", params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(204)
+      expect(Membership.exists?(@membership.id)).to be false
+      expect(User.exists?(@user.id)).to be true
+    end
+  end
 end

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -429,9 +429,9 @@ describe 'Requesting Tree resources', :type => :request  do
   end
 
   describe 'select-all destroy sorting on a collection the role cannot read' do
-    # ResourcesGetter.get_ids_from_request never calls #perform (only .query_for_batch, built
-    # in the constructor) — assert_sort_readable! lived only in #perform, so a sort on a denied
-    # collection reordered the batch of ids to delete without ever being checked.
+    # ResourcesGetter.get_ids_from_request never called #perform (only .query_for_batch, built in
+    # the constructor), and assert_sort_readable! used to live only inside #perform — a sort on a
+    # denied collection reordered the batch of ids to delete without ever being checked.
     it 'refuses with a 403, instead of reordering the ids to delete by an unreadable column' do
       params = {
         data: {

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -381,7 +381,18 @@ describe 'Requesting Tree resources', :type => :request  do
       # `browse` (not `read`) is what forest_authorize! gates the route on; a role can legitimately
       # browse a collection without having its own `read` — the root is still pinned readable for
       # this guard, which must not re-derive a denial for it from a permission it is not gated on.
-      Rails.cache.write('forest.collections', { 'Tree' => { 'browse' => [1], 'read' => [], 'edit' => [], 'add' => [], 'delete' => [], 'export' => [], 'actions' => {} } })
+      # Stubbed at the source (persistently denied), not written to the derived cache directly —
+      # the forced retry-on-denial would otherwise re-read this same outer before block's stub,
+      # which grants Tree read, and mask whether the pin actually held.
+      enabled = { 'roles' => [1] }
+      disabled = { 'roles' => [] }
+      allow_any_instance_of(ForestLiana::Ability::Fetch).to receive(:get_permissions)
+        .with('/liana/v4/permissions/environment').and_return(
+          'collections' => {
+            'Tree' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => disabled, 'editEnabled' => disabled, 'addEnabled' => disabled, 'deleteEnabled' => disabled, 'exportEnabled' => disabled }, 'actions' => {} }
+          }
+        )
+      Rails.cache.delete('forest.collections')
       params = {
         filters: JSON.generate({ 'field' => 'name', 'operator' => 'present' }),
         page: { 'number' => '1', 'size' => '10' },

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -363,6 +363,28 @@ describe 'Requesting Tree resources', :type => :request  do
     end
   end
 
+  describe 'select-all destroy naming a filter on a collection the role cannot read' do
+    it 'refuses with a 403 body instead of a bodiless 500' do
+      params = {
+        data: {
+          attributes: {
+            collection_name: 'Tree',
+            all_records: true,
+            all_records_subset_query: {
+              filters: JSON.generate({ 'field' => 'island:name', 'operator' => 'equal', 'value' => 'Lemon Island' })
+            }
+          }
+        }
+      }
+
+      delete '/forest/Tree', params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(403)
+      expect(JSON.parse(response.body)['errors'][0]['detail'])
+        .to eq "You cannot filter on 'island:name': you are not allowed to read the 'Island' collection."
+    end
+  end
+
   describe 'csv' do
     it 'should return CSV with correct headers and data' do
       params = {

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -277,6 +277,20 @@ describe 'Requesting Tree resources', :type => :request  do
       expect(JSON.parse(response.body)['errors'][0]['detail']).to eq 'Invalid condition format'
     end
 
+    it 'lets a malformed aggregation reach the parser\'s own 422, rather than crashing this guard' do
+      params = {
+        filters: JSON.generate({ 'aggregator' => 'and', 'conditions' => { 'field' => 'name' } }),
+        page: { 'number' => '1', 'size' => '10' },
+        searchExtended: '0',
+        timezone: 'Europe/Paris'
+      }
+
+      get '/forest/Tree', params: params, headers: headers
+
+      expect(response.status).to eq(422)
+      expect(JSON.parse(response.body)['errors'][0]['detail']).to eq 'Filters cannot be a raw value'
+    end
+
     describe 'filtering on a column of a collection the role cannot read' do
       params = {
         filters: JSON.generate({ 'field' => 'island:name', 'operator' => 'equal', 'value' => 'Lemon Island' }),

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -263,6 +263,20 @@ describe 'Requesting Tree resources', :type => :request  do
   end
 
   describe 'read-permission enforcement on filter and sort' do
+    it 'lets a malformed filter reach the parser\'s own 422, rather than crashing this guard' do
+      params = {
+        filters: JSON.generate({ 'operator' => 'equal', 'value' => 'x' }),
+        page: { 'number' => '1', 'size' => '10' },
+        searchExtended: '0',
+        timezone: 'Europe/Paris'
+      }
+
+      get '/forest/Tree', params: params, headers: headers
+
+      expect(response.status).to eq(422)
+      expect(JSON.parse(response.body)['errors'][0]['detail']).to eq 'Invalid condition format'
+    end
+
     describe 'filtering on a column of a collection the role cannot read' do
       params = {
         filters: JSON.generate({ 'field' => 'island:name', 'operator' => 'equal', 'value' => 'Lemon Island' }),

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -291,6 +291,20 @@ describe 'Requesting Tree resources', :type => :request  do
       expect(JSON.parse(response.body)['errors'][0]['detail']).to eq 'Filters cannot be a raw value'
     end
 
+    it 'lets an aggregation with a nil conditions reach the parser\'s own 422, rather than crashing this guard' do
+      params = {
+        filters: JSON.generate({ 'aggregator' => 'and', 'conditions' => nil }),
+        page: { 'number' => '1', 'size' => '10' },
+        searchExtended: '0',
+        timezone: 'Europe/Paris'
+      }
+
+      get '/forest/Tree', params: params, headers: headers
+
+      expect(response.status).to eq(422)
+      expect(JSON.parse(response.body)['errors'][0]['detail']).to eq 'Filters cannot be a raw value'
+    end
+
     describe 'filtering on a column of a collection the role cannot read' do
       params = {
         filters: JSON.generate({ 'field' => 'island:name', 'operator' => 'equal', 'value' => 'Lemon Island' }),

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -305,6 +305,36 @@ describe 'Requesting Tree resources', :type => :request  do
       expect(JSON.parse(response.body)['errors'][0]['detail']).to eq 'Filters cannot be a raw value'
     end
 
+    it 'lets a non-blank top-level non-Hash filter reach the parser\'s own 422, rather than crashing this guard' do
+      params = {
+        filters: JSON.generate(5),
+        page: { 'number' => '1', 'size' => '10' },
+        searchExtended: '0',
+        timezone: 'Europe/Paris'
+      }
+
+      get '/forest/Tree', params: params, headers: headers
+
+      expect(response.status).to eq(422)
+      expect(JSON.parse(response.body)['errors'][0]['detail']).to eq 'Filters cannot be a raw value'
+    end
+
+    # An empty Array is `blank?`, same as no filter at all: it's dropped before reaching
+    # FiltersParser (long-standing behavior, unrelated to this guard) — this only pins that it no
+    # longer crashes on filter.key?/node['aggregator'], not the 422 the non-blank case above gets.
+    it 'does not crash on a top-level empty-Array filter' do
+      params = {
+        filters: JSON.generate([]),
+        page: { 'number' => '1', 'size' => '10' },
+        searchExtended: '0',
+        timezone: 'Europe/Paris'
+      }
+
+      get '/forest/Tree', params: params, headers: headers
+
+      expect(response.status).to eq(200)
+    end
+
     describe 'filtering on a column of a collection the role cannot read' do
       params = {
         filters: JSON.generate({ 'field' => 'island:name', 'operator' => 'equal', 'value' => 'Lemon Island' }),

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -295,10 +295,14 @@ describe 'Requesting Tree resources', :type => :request  do
         expect(body['errors'][0]['data']).to eq('action' => 'filter on', 'field' => 'island:name')
       end
 
-      it 'refuses count the same way' do
+      it 'refuses count the same way, naming the path and the collection' do
         get '/forest/Tree/count', params: params, headers: headers
 
         expect(response.status).to eq(403)
+        body = JSON.parse(response.body)
+        expect(body['errors'][0]['detail'])
+          .to eq "You cannot filter on 'island:name': you are not allowed to read the 'Island' collection."
+        expect(body['errors'][0]['data']).to eq('action' => 'filter on', 'field' => 'island:name')
       end
 
       it 'refuses csv export the same way' do

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -428,6 +428,31 @@ describe 'Requesting Tree resources', :type => :request  do
     end
   end
 
+  describe 'select-all destroy sorting on a collection the role cannot read' do
+    # ResourcesGetter.get_ids_from_request never calls #perform (only .query_for_batch, built
+    # in the constructor) — assert_sort_readable! lived only in #perform, so a sort on a denied
+    # collection reordered the batch of ids to delete without ever being checked.
+    it 'refuses with a 403, instead of reordering the ids to delete by an unreadable column' do
+      params = {
+        data: {
+          attributes: {
+            collection_name: 'Tree',
+            all_records: true,
+            all_records_subset_query: {
+              sort: '-island.name'
+            }
+          }
+        }
+      }
+
+      delete '/forest/Tree', params: JSON.dump(params), headers: headers
+
+      expect(response.status).to eq(403)
+      expect(JSON.parse(response.body)['errors'][0]['detail'])
+        .to eq "You cannot sort on 'island:name': you are not allowed to read the 'Island' collection."
+    end
+  end
+
   describe 'csv' do
     it 'should return CSV with correct headers and data' do
       params = {

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -262,6 +262,93 @@ describe 'Requesting Tree resources', :type => :request  do
     end
   end
 
+  describe 'read-permission enforcement on filter and sort' do
+    describe 'filtering on a column of a collection the role cannot read' do
+      params = {
+        filters: JSON.generate({ 'field' => 'island:name', 'operator' => 'equal', 'value' => 'Lemon Island' }),
+        page: { 'number' => '1', 'size' => '10' },
+        searchExtended: '0',
+        timezone: 'Europe/Paris'
+      }
+
+      it 'refuses index with a 403 naming the path and the collection' do
+        get '/forest/Tree', params: params, headers: headers
+
+        expect(response.status).to eq(403)
+        body = JSON.parse(response.body)
+        expect(body['errors'][0]['detail'])
+          .to eq "You cannot filter on 'island:name': you are not allowed to read the 'Island' collection."
+        expect(body['errors'][0]['data']).to eq('action' => 'filter on', 'field' => 'island:name')
+      end
+
+      it 'refuses count the same way' do
+        get '/forest/Tree/count', params: params, headers: headers
+
+        expect(response.status).to eq(403)
+      end
+
+      it 'refuses csv export the same way' do
+        get '/forest/Tree.csv', params: params.merge(header: 'id'), headers: headers
+
+        expect(response.status).to eq(403)
+      end
+    end
+
+    describe 'sorting on a column of a collection the role cannot read' do
+      params = {
+        sort: '-island.name',
+        page: { 'number' => '1', 'size' => '10' },
+        searchExtended: '0',
+        timezone: 'Europe/Paris'
+      }
+
+      it 'refuses index' do
+        get '/forest/Tree', params: params, headers: headers
+
+        expect(response.status).to eq(403)
+        expect(JSON.parse(response.body)['errors'][0]['detail'])
+          .to eq "You cannot sort on 'island:name': you are not allowed to read the 'Island' collection."
+      end
+
+      it 'does not refuse count, which never applies the sort' do
+        get '/forest/Tree/count', params: params, headers: headers
+
+        expect(response.status).to eq(200)
+      end
+    end
+
+    it 'never checks a scope, even one referencing a column of an unreadable collection' do
+      allow(ForestLiana::ScopeManager).to receive(:fetch_scopes).and_return(
+        'scopes' => {
+          'Tree' => { 'aggregator' => 'and', 'conditions' => [{ 'field' => 'island:name', 'operator' => 'present' }] }
+        },
+        'team' => { 'id' => '1', 'name' => 'Operations' }
+      )
+      params = { page: { 'number' => '1', 'size' => '10' }, searchExtended: '0', timezone: 'Europe/Paris' }
+
+      get '/forest/Tree', params: params, headers: headers
+
+      expect(response.status).to eq(200)
+    end
+
+    it 'never refuses a filter on the root collection, even when the root has no read permission of its own' do
+      # `browse` (not `read`) is what forest_authorize! gates the route on; a role can legitimately
+      # browse a collection without having its own `read` — the root is still pinned readable for
+      # this guard, which must not re-derive a denial for it from a permission it is not gated on.
+      Rails.cache.write('forest.collections', { 'Tree' => { 'browse' => [1], 'read' => [], 'edit' => [], 'add' => [], 'delete' => [], 'export' => [], 'actions' => {} } })
+      params = {
+        filters: JSON.generate({ 'field' => 'name', 'operator' => 'present' }),
+        page: { 'number' => '1', 'size' => '10' },
+        searchExtended: '0',
+        timezone: 'Europe/Paris'
+      }
+
+      get '/forest/Tree', params: params, headers: headers
+
+      expect(response.status).to eq(200)
+    end
+  end
+
   describe 'csv' do
     it 'should return CSV with correct headers and data' do
       params = {

--- a/spec/services/forest_liana/ability/assert_can_read_query_fields_spec.rb
+++ b/spec/services/forest_liana/ability/assert_can_read_query_fields_spec.rb
@@ -1,0 +1,152 @@
+module ForestLiana
+  module Ability
+    describe Ability do
+      let(:dummy_class) { Class.new { extend ForestLiana::Ability } }
+      let(:user) { { 'id' => 1, 'roleId' => 1, 'rendering_id' => '1' } }
+
+      def write_permissions(collection_reads)
+        permissions = collection_reads.to_h do |name, readable|
+          [name, { 'browse' => readable ? [1] : [], 'read' => readable ? [1] : [], 'edit' => [], 'add' => [], 'delete' => [], 'export' => [], :actions => {} }]
+        end
+
+        Rails.cache.write('forest.collections', permissions)
+      end
+
+      before do
+        Rails.cache.clear
+        Rails.cache.write('forest.users', { '1' => user })
+        Rails.cache.write('forest.has_permission', true)
+      end
+
+      describe 'assert_can_read_query_fields' do
+        it 'does nothing when neither a filter nor a sort path is given' do
+          write_permissions({})
+
+          expect { dummy_class.assert_can_read_query_fields(user, Tree) }.not_to raise_error
+        end
+
+        it 'refuses a filter on a column of an unreadable collection, naming the path and collection' do
+          write_permissions('Tree' => true, 'Island' => false)
+
+          expect { dummy_class.assert_can_read_query_fields(user, Tree, filter_paths: ['island:name']) }
+            .to raise_error(
+              ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError,
+              "You cannot filter on 'island:name': you are not allowed to read the 'Island' collection."
+            )
+        end
+
+        it 'refuses a sort on a column of an unreadable collection, naming the path and collection' do
+          write_permissions('Tree' => true, 'Island' => false)
+
+          expect { dummy_class.assert_can_read_query_fields(user, Tree, sort_paths: ['island:name']) }
+            .to raise_error(
+              ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError,
+              "You cannot sort on 'island:name': you are not allowed to read the 'Island' collection."
+            )
+        end
+
+        it 'serves a filter reaching a readable collection' do
+          write_permissions('Tree' => true, 'Island' => true)
+
+          expect { dummy_class.assert_can_read_query_fields(user, Tree, filter_paths: ['island:name']) }
+            .not_to raise_error
+        end
+
+        it 'serves a filter reaching a readable column through an unreadable collection' do
+          write_permissions('Tree' => true, 'Island' => false, 'Location' => true)
+
+          expect { dummy_class.assert_can_read_query_fields(user, Tree, filter_paths: ['island:location:coordinates']) }
+            .not_to raise_error
+        end
+
+        it 'never checks the root collection, even when it is absent from the permission payload' do
+          write_permissions('Location' => true)
+
+          expect { dummy_class.assert_can_read_query_fields(user, Tree, filter_paths: ['name'], sort_paths: ['id']) }
+            .not_to raise_error
+        end
+
+        it 'raises on the first denied usage rather than collecting every one of them' do
+          write_permissions('Tree' => true, 'Island' => false, 'User' => false)
+
+          expect { dummy_class.assert_can_read_query_fields(user, Tree, filter_paths: %w[island:name owner:name]) }
+            .to raise_error(ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError)
+        end
+
+        it 'does not raise for a filter path FieldPath cannot resolve, leaving it to the parser that runs next' do
+          write_permissions('Tree' => true)
+
+          expect { dummy_class.assert_can_read_query_fields(user, Tree, filter_paths: ['unknown:id']) }
+            .not_to raise_error
+        end
+
+        it 'raises for a sort path FieldPath cannot resolve, since nothing else validates it' do
+          write_permissions('Tree' => true)
+
+          expect { dummy_class.assert_can_read_query_fields(user, Tree, sort_paths: ['unknown:id']) }
+            .to raise_error(ForestLiana::Errors::HTTP422Error, "Relation not found: 'Tree.unknown'")
+        end
+
+        describe 'polymorphic' do
+          it 'serves a filter on a relation whose every target is readable' do
+            write_permissions('Address' => true, 'User' => true, 'Island' => true)
+            Island.class_eval { has_many :addresses, as: :addressable }
+
+            expect { dummy_class.assert_can_read_query_fields(user, Address, filter_paths: ['addressable:name']) }
+              .not_to raise_error
+          ensure
+            Island._reflections.delete('addresses')
+            Island.reflections.delete('addresses')
+            %w[addresses addresses= address_ids address_ids=].each { |m| Island.undef_method(m) rescue nil }
+          end
+
+          it 'refuses a filter on a relation with one denied target' do
+            write_permissions('Address' => true, 'User' => false)
+
+            expect { dummy_class.assert_can_read_query_fields(user, Address, filter_paths: ['addressable:name']) }
+              .to raise_error(
+                ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError,
+                "You cannot filter on 'addressable:name': you are not allowed to read the 'User' collection."
+              )
+          end
+
+          it 'refuses a sort on a relation with no declared target' do
+            write_permissions('Tree' => true)
+            Tree.class_eval { belongs_to :subject, polymorphic: true, optional: true }
+
+            expect { dummy_class.assert_can_read_query_fields(user, Tree, sort_paths: ['subject:id']) }
+              .to raise_error(
+                ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError,
+                "You cannot sort on 'subject:id': you are not allowed to read an unresolved polymorphic relation."
+              )
+          ensure
+            Tree._reflections.delete('subject')
+            Tree.reflections.delete('subject')
+            %w[subject subject= subject_id subject_type].each { |m| Tree.undef_method(m) rescue nil }
+          end
+        end
+
+        describe 'a smart belongsTo field (is_virtual, no ActiveRecord reflection)' do
+          before do
+            forest_collection = double('forest_collection')
+            allow(forest_collection).to receive(:name).and_return('Tree')
+            allow(forest_collection).to receive(:fields_smart_belongs_to).and_return(
+              [{ field: :organization, reference: 'Organization.id', is_virtual: true, type: 'String' }]
+            )
+            allow(ForestLiana).to receive(:apimap).and_return([forest_collection])
+          end
+
+          it 'checks read on the referenced collection, not on the root it is declared on' do
+            write_permissions('Tree' => true, 'Organization' => false)
+
+            expect { dummy_class.assert_can_read_query_fields(user, Tree, filter_paths: ['organization']) }
+              .to raise_error(
+                ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError,
+                "You cannot filter on 'organization': you are not allowed to read the 'Organization' collection."
+              )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/forest_liana/ability/assert_can_read_query_fields_spec.rb
+++ b/spec/services/forest_liana/ability/assert_can_read_query_fields_spec.rb
@@ -114,6 +114,13 @@ module ForestLiana
             .not_to raise_error
         end
 
+        it 'does not raise for a filter path deeper than FiltersParser reads, even one FieldPath resolves to a denied collection' do
+          write_permissions('Tree' => true, 'Island' => true, 'Location' => false)
+
+          expect { dummy_class.assert_can_read_query_fields(user, Tree, filter_paths: ['island:location:name']) }
+            .not_to raise_error
+        end
+
         it 'raises for a sort path FieldPath cannot resolve, since nothing else validates it' do
           write_permissions('Tree' => true)
 

--- a/spec/services/forest_liana/ability/assert_can_read_query_fields_spec.rb
+++ b/spec/services/forest_liana/ability/assert_can_read_query_fields_spec.rb
@@ -97,8 +97,6 @@ module ForestLiana
 
           dummy_class.assert_can_read_query_fields(user, Tree, filter_paths: ['name'], sort_paths: ['id'])
 
-          # root_name is the only usage here and is excluded before read_permissions ever sees it,
-          # so read_permissions has nothing left to fetch: no call reaches the permissions source.
           expect(environment_fetch_count).to eq(0)
         end
 

--- a/spec/services/forest_liana/ability/assert_can_read_query_fields_spec.rb
+++ b/spec/services/forest_liana/ability/assert_can_read_query_fields_spec.rb
@@ -4,6 +4,10 @@ module ForestLiana
       let(:dummy_class) { Class.new { extend ForestLiana::Ability } }
       let(:user) { { 'id' => 1, 'roleId' => 1, 'rendering_id' => '1' } }
 
+      def environment_fetch_count
+        @environment_fetch_counter[:calls]
+      end
+
       def write_permissions(collection_reads)
         raw_collections = collection_reads.to_h do |name, readable|
           enabled = { 'roles' => readable ? [1] : [] }
@@ -17,11 +21,18 @@ module ForestLiana
           }]
         end
 
+        # A block passed to allow_any_instance_of runs with `self` bound to whichever instance
+        # receives the call, not this example — count through a closure instead of an ivar.
+        counter = { calls: 0 }
+        @environment_fetch_counter = counter
         # read_permissions may force a real refetch on a denial (a stale cache may sit behind a
         # just-granted permission) — stub the source instead of writing the derived cache directly,
         # so that refetch sees the same permissions rather than hitting the network.
         allow_any_instance_of(ForestLiana::Ability::Fetch).to receive(:get_permissions)
-          .with('/liana/v4/permissions/environment').and_return('collections' => raw_collections)
+          .with('/liana/v4/permissions/environment') do
+            counter[:calls] += 1
+            { 'collections' => raw_collections }
+          end
       end
 
       before do
@@ -76,6 +87,19 @@ module ForestLiana
 
           expect { dummy_class.assert_can_read_query_fields(user, Tree, filter_paths: ['name'], sort_paths: ['id']) }
             .not_to raise_error
+        end
+
+        it 'does not pay for the root pin with a wasted retry-on-denial refetch' do
+          # A root usage would resolve to `root_name` itself and, before this fix, get handed to
+          # read_permissions anyway — which sees it "denied" (absent here) and force-refetches, even
+          # though the very next line was always going to override it back to readable regardless.
+          write_permissions('Location' => true)
+
+          dummy_class.assert_can_read_query_fields(user, Tree, filter_paths: ['name'], sort_paths: ['id'])
+
+          # root_name is the only usage here and is excluded before read_permissions ever sees it,
+          # so read_permissions has nothing left to fetch: no call reaches the permissions source.
+          expect(environment_fetch_count).to eq(0)
         end
 
         it 'raises on the first denied usage rather than collecting every one of them' do

--- a/spec/services/forest_liana/ability/assert_can_read_query_fields_spec.rb
+++ b/spec/services/forest_liana/ability/assert_can_read_query_fields_spec.rb
@@ -114,11 +114,25 @@ module ForestLiana
             .not_to raise_error
         end
 
-        it 'does not raise for a filter path deeper than FiltersParser reads, even one FieldPath resolves to a denied collection' do
+        it 'refuses a filter path truncated to a real relation name, even though the parser would only ever crash on it' do
+          # island:location:name truncates to island:location, which fully resolves to Location
+          # (location is itself a real reflection) — the parser instead quotes segment 1
+          # ("location") as a raw column of Island's own table, which doesn't exist, so it can only
+          # ever 500. Denying here trades that crash for a clean 403 without ever reaching the query.
           write_permissions('Tree' => true, 'Island' => true, 'Location' => false)
 
           expect { dummy_class.assert_can_read_query_fields(user, Tree, filter_paths: ['island:location:name']) }
-            .not_to raise_error
+            .to raise_error(ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError)
+        end
+
+        it 'refuses a filter path where a later segment names a real column of the collection the parser actually filters on' do
+          # island:name:id: the parser quotes segment 1 (name) but validates existence against the
+          # last one (id, present on every model) — 'id' always passing let this run as a live,
+          # unchecked filter on Island.name, one starts_with guess per request, on a denied Island.
+          write_permissions('Tree' => true, 'Island' => false)
+
+          expect { dummy_class.assert_can_read_query_fields(user, Tree, filter_paths: ['island:name:id']) }
+            .to raise_error(ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError)
         end
 
         it 'raises for a sort path FieldPath cannot resolve, since nothing else validates it' do

--- a/spec/services/forest_liana/ability/assert_can_read_query_fields_spec.rb
+++ b/spec/services/forest_liana/ability/assert_can_read_query_fields_spec.rb
@@ -5,11 +5,23 @@ module ForestLiana
       let(:user) { { 'id' => 1, 'roleId' => 1, 'rendering_id' => '1' } }
 
       def write_permissions(collection_reads)
-        permissions = collection_reads.to_h do |name, readable|
-          [name, { 'browse' => readable ? [1] : [], 'read' => readable ? [1] : [], 'edit' => [], 'add' => [], 'delete' => [], 'export' => [], :actions => {} }]
+        raw_collections = collection_reads.to_h do |name, readable|
+          enabled = { 'roles' => readable ? [1] : [] }
+          disabled = { 'roles' => [] }
+          [name, {
+            'collection' => {
+              'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => disabled,
+              'addEnabled' => disabled, 'deleteEnabled' => disabled, 'exportEnabled' => disabled
+            },
+            'actions' => {}
+          }]
         end
 
-        Rails.cache.write('forest.collections', permissions)
+        # read_permissions may force a real refetch on a denial (a stale cache may sit behind a
+        # just-granted permission) — stub the source instead of writing the derived cache directly,
+        # so that refetch sees the same permissions rather than hitting the network.
+        allow_any_instance_of(ForestLiana::Ability::Fetch).to receive(:get_permissions)
+          .with('/liana/v4/permissions/environment').and_return('collections' => raw_collections)
       end
 
       before do

--- a/spec/services/forest_liana/ability/assert_can_read_query_fields_spec.rb
+++ b/spec/services/forest_liana/ability/assert_can_read_query_fields_spec.rb
@@ -68,6 +68,17 @@ module ForestLiana
             )
         end
 
+        it 'refuses a sort naming segment 1s own collection, even when segment 2 also happens to be a real relation' do
+          # sort=island.location.name truncates (sort_field_path) to island:location — segment 2
+          # ("location") is itself a real reflection, but detect_reference still only ever formats
+          # it as a column of Island's own table (isle."location"), the same segment-2 ambiguity
+          # closed for filters. Location being readable is irrelevant; Island is what's touched.
+          write_permissions('Tree' => true, 'Island' => false, 'Location' => true)
+
+          expect { dummy_class.assert_can_read_query_fields(user, Tree, sort_paths: ['island:location']) }
+            .to raise_error(ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError)
+        end
+
         it 'serves a filter reaching a readable collection' do
           write_permissions('Tree' => true, 'Island' => true)
 
@@ -75,11 +86,14 @@ module ForestLiana
             .not_to raise_error
         end
 
-        it 'serves a filter reaching a readable column through an unreadable collection' do
+        it 'refuses a filter naming a column past segment 1, on segment 1s own collection, not the one the path fully resolves to' do
+          # FiltersParser never actually joins two hops deep — island:location:coordinates only
+          # ever filters (or, here, since Island has no "location" column, 422s) on Island itself.
+          # Location being readable is irrelevant; Island is what the query would really touch.
           write_permissions('Tree' => true, 'Island' => false, 'Location' => true)
 
           expect { dummy_class.assert_can_read_query_fields(user, Tree, filter_paths: ['island:location:coordinates']) }
-            .not_to raise_error
+            .to raise_error(ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError)
         end
 
         it 'never checks the root collection, even when it is absent from the permission payload' do
@@ -107,25 +121,23 @@ module ForestLiana
             .to raise_error(ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError)
         end
 
-        it 'does not raise for a filter path FieldPath cannot resolve, leaving it to the parser that runs next' do
+        it 'does not raise for a filter path naming an unresolvable segment 1, since it resolves to the pinned-readable root' do
           write_permissions('Tree' => true)
 
           expect { dummy_class.assert_can_read_query_fields(user, Tree, filter_paths: ['unknown:id']) }
             .not_to raise_error
         end
 
-        it 'refuses a filter path truncated to a real relation name, even though the parser would only ever crash on it' do
-          # island:location:name truncates to island:location, which fully resolves to Location
-          # (location is itself a real reflection) — the parser instead quotes segment 1
-          # ("location") as a raw column of Island's own table, which doesn't exist, so it can only
-          # ever 500. Denying here trades that crash for a clean 403 without ever reaching the query.
-          write_permissions('Tree' => true, 'Island' => true, 'Location' => false)
+        it 'does not raise for an empty or colon-only filter path, leaving it to the parser rather than crashing on nil' do
+          # ''.split(':').first is nil, and FieldPath.leaf_collection_names(nil) blows up on
+          # nil.partition — partition(':').first returns '' instead, which resolves to the root.
+          write_permissions('Tree' => true)
 
-          expect { dummy_class.assert_can_read_query_fields(user, Tree, filter_paths: ['island:location:name']) }
-            .to raise_error(ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError)
+          expect { dummy_class.assert_can_read_query_fields(user, Tree, filter_paths: ['', ':', '::']) }
+            .not_to raise_error
         end
 
-        it 'refuses a filter path where a later segment names a real column of the collection the parser actually filters on' do
+        it 'refuses a filter path where a later segment names a real column, on the segment 1 collection the parser actually filters on' do
           # island:name:id: the parser quotes segment 1 (name) but validates existence against the
           # last one (id, present on every model) — 'id' always passing let this run as a live,
           # unchecked filter on Island.name, one starts_with guess per request, on a denied Island.
@@ -135,11 +147,14 @@ module ForestLiana
             .to raise_error(ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError)
         end
 
-        it 'raises for a sort path FieldPath cannot resolve, since nothing else validates it' do
+        it 'does not raise for a sort path naming an unresolvable segment 1 either, checking only segment 1 like a filter' do
+          # Segment 1 is checked, not the full path resolved: nothing downstream validates a sort
+          # path (unlike a filter, which FiltersParser still validates on its own), so a genuinely
+          # malformed one here surfaces as sort_query's own error later, not a 422 from this guard.
           write_permissions('Tree' => true)
 
           expect { dummy_class.assert_can_read_query_fields(user, Tree, sort_paths: ['unknown:id']) }
-            .to raise_error(ForestLiana::Errors::HTTP422Error, "Relation not found: 'Tree.unknown'")
+            .not_to raise_error
         end
 
         describe 'polymorphic' do

--- a/spec/services/forest_liana/belongs_to_updater_spec.rb
+++ b/spec/services/forest_liana/belongs_to_updater_spec.rb
@@ -24,6 +24,12 @@ module ForestLiana
 
         expect(described_class.replaces_destructively?(association)).to be false
       end
+
+      it 'is false for a has_one :through with dependent: :destroy (Rails ignores dependent: there)' do
+        association = double('association', macro: :has_one, options: { through: :island, dependent: :destroy })
+
+        expect(described_class.replaces_destructively?(association)).to be false
+      end
     end
   end
 end

--- a/spec/services/forest_liana/belongs_to_updater_spec.rb
+++ b/spec/services/forest_liana/belongs_to_updater_spec.rb
@@ -1,0 +1,29 @@
+module ForestLiana
+  describe BelongsToUpdater do
+    describe '.replaces_destructively?' do
+      it 'is true for a has_one with dependent: :destroy' do
+        association = double('association', macro: :has_one, options: { dependent: :destroy })
+
+        expect(described_class.replaces_destructively?(association)).to be true
+      end
+
+      it 'is true for a has_one with dependent: :delete' do
+        association = double('association', macro: :has_one, options: { dependent: :delete })
+
+        expect(described_class.replaces_destructively?(association)).to be true
+      end
+
+      it 'is false for a has_one with no dependent option (Rails only nullifies the old target)' do
+        association = double('association', macro: :has_one, options: {})
+
+        expect(described_class.replaces_destructively?(association)).to be false
+      end
+
+      it 'is false for a belongsTo, even with a dependent option' do
+        association = double('association', macro: :belongs_to, options: { dependent: :destroy })
+
+        expect(described_class.replaces_destructively?(association)).to be false
+      end
+    end
+  end
+end

--- a/spec/services/forest_liana/filters_parser_spec.rb
+++ b/spec/services/forest_liana/filters_parser_spec.rb
@@ -39,6 +39,25 @@ module ForestLiana
         expect(described_class.field_paths(presence_condition)).to eq(['name'])
       end
 
+      # A malformed leaf must reach FiltersParser#ensure_valid_condition's own 422, not crash a
+      # caller that expects every path to be a String (FieldPath in particular).
+      it 'leaves out a leaf with no field, rather than answering a nil path' do
+        expect(described_class.field_paths({ 'operator' => 'equal', 'value' => 'x' })).to eq([])
+      end
+
+      it 'leaves out a leaf whose field is not a String' do
+        expect(described_class.field_paths({ 'field' => ['name'], 'operator' => 'equal', 'value' => 'x' })).to eq([])
+      end
+
+      it 'keeps the valid leaves of an aggregation that also has a malformed one' do
+        filters = {
+          'aggregator' => 'and',
+          'conditions' => [{ 'operator' => 'equal', 'value' => 'x' }, presence_condition]
+        }
+
+        expect(described_class.field_paths(filters)).to eq(['name'])
+      end
+
       it 'answers every leaf field of a deeply nested aggregation' do
         filters = {
           'aggregator' => 'or',

--- a/spec/services/forest_liana/filters_parser_spec.rb
+++ b/spec/services/forest_liana/filters_parser_spec.rb
@@ -30,6 +30,33 @@ module ForestLiana
       Island.destroy_all
     }
 
+    describe '.field_paths' do
+      it 'answers an empty list for a blank filter' do
+        expect(described_class.field_paths(nil)).to eq([])
+      end
+
+      it 'answers the single field of a leaf condition' do
+        expect(described_class.field_paths(presence_condition)).to eq(['name'])
+      end
+
+      it 'answers every leaf field of a deeply nested aggregation' do
+        filters = {
+          'aggregator' => 'or',
+          'conditions' => [
+            {
+              'aggregator' => 'and', 'conditions' => [
+                { 'aggregator' => 'or', 'conditions' => [date_condition_1, simple_condition_1] },
+                simple_condition_2
+              ]
+            },
+            belongs_to_condition
+          ]
+        }
+
+        expect(described_class.field_paths(filters)).to eq(%w[created_at name name trees:age])
+      end
+    end
+
     describe 'apply_filters' do
       let(:parsed_filters) { filter_parser.apply_filters }
 

--- a/spec/services/forest_liana/filters_parser_spec.rb
+++ b/spec/services/forest_liana/filters_parser_spec.rb
@@ -49,6 +49,13 @@ module ForestLiana
         expect(described_class.field_paths({ 'field' => ['name'], 'operator' => 'equal', 'value' => 'x' })).to eq([])
       end
 
+      # A non-Hash node (a top-level `filters=[]`, say) must reach ensure_valid_aggregation's own
+      # 422 once apply_filters runs, not crash here on node['aggregator'] first.
+      it 'answers an empty list for a non-Hash filter' do
+        expect(described_class.field_paths([])).to eq([])
+        expect(described_class.field_paths('foo')).to eq([])
+      end
+
       it 'keeps the valid leaves of an aggregation that also has a malformed one' do
         filters = {
           'aggregator' => 'and',

--- a/spec/services/forest_liana/filters_parser_spec.rb
+++ b/spec/services/forest_liana/filters_parser_spec.rb
@@ -67,6 +67,21 @@ module ForestLiana
         expect(described_class.field_paths(filters)).to eq([])
       end
 
+      it 'answers an empty list for an aggregation whose conditions is nil' do
+        filters = { 'aggregator' => 'and', 'conditions' => nil }
+
+        expect(described_class.field_paths(filters)).to eq([])
+      end
+
+      it 'answers an empty list for a malformed aggregation nested inside a well-formed one' do
+        filters = {
+          'aggregator' => 'and',
+          'conditions' => [presence_condition, { 'aggregator' => 'or', 'conditions' => { 'field' => 'name' } }]
+        }
+
+        expect(described_class.field_paths(filters)).to eq(['name'])
+      end
+
       it 'answers every leaf field of a deeply nested aggregation' do
         filters = {
           'aggregator' => 'or',

--- a/spec/services/forest_liana/filters_parser_spec.rb
+++ b/spec/services/forest_liana/filters_parser_spec.rb
@@ -58,6 +58,15 @@ module ForestLiana
         expect(described_class.field_paths(filters)).to eq(['name'])
       end
 
+      # A non-Array `conditions` (a raw Hash, here) must reach ensure_valid_aggregation's own
+      # 422 the same way a malformed leaf reaches ensure_valid_condition's — not crash this guard
+      # with a bare Hash#each yielding [key, value] pairs where a condition Hash is expected.
+      it 'answers an empty list for an aggregation whose conditions is not an Array' do
+        filters = { 'aggregator' => 'and', 'conditions' => { 'field' => 'name' } }
+
+        expect(described_class.field_paths(filters)).to eq([])
+      end
+
       it 'answers every leaf field of a deeply nested aggregation' do
         filters = {
           'aggregator' => 'or',

--- a/spec/services/forest_liana/has_many_associator_spec.rb
+++ b/spec/services/forest_liana/has_many_associator_spec.rb
@@ -13,6 +13,14 @@ module ForestLiana
 
         expect(described_class.authorize_target(association)).to eq(Membership)
       end
+
+      it 'falls back to the far collection when the join model is excluded from the schema' do
+        allow(ForestLiana::SchemaUtils).to receive(:model_included?).with(Membership).and_return(false)
+        through_reflection = double('through_reflection', klass: Membership)
+        association = double('association', klass: User, through_reflection: through_reflection, options: { through: :memberships })
+
+        expect(described_class.authorize_target(association)).to eq(User)
+      end
     end
   end
 end

--- a/spec/services/forest_liana/has_many_associator_spec.rb
+++ b/spec/services/forest_liana/has_many_associator_spec.rb
@@ -1,0 +1,18 @@
+module ForestLiana
+  describe HasManyAssociator do
+    describe '.authorize_target' do
+      it 'is the far collection for a plain has_many' do
+        association = double('association', klass: Tree, options: {})
+
+        expect(described_class.authorize_target(association)).to eq(Tree)
+      end
+
+      it 'is the join collection for a through association, not the far one' do
+        through_reflection = double('through_reflection', klass: Membership)
+        association = double('association', klass: User, through_reflection: through_reflection, options: { through: :memberships })
+
+        expect(described_class.authorize_target(association)).to eq(Membership)
+      end
+    end
+  end
+end

--- a/spec/services/forest_liana/has_many_dissociator_spec.rb
+++ b/spec/services/forest_liana/has_many_dissociator_spec.rb
@@ -30,6 +30,39 @@ module ForestLiana
 
         expect(described_class.destroys_on_unlink?(association)).to be false
       end
+
+      it 'is true for a through association with no dependent option (Rails hard-deletes the join row by default)' do
+        association = double('association', macro: :has_many, options: { through: :memberships })
+
+        expect(described_class.destroys_on_unlink?(association)).to be true
+      end
+
+      it 'is true for a through association with dependent: :destroy' do
+        association = double('association', macro: :has_many, options: { through: :memberships, dependent: :destroy })
+
+        expect(described_class.destroys_on_unlink?(association)).to be true
+      end
+
+      it 'is false for a through association with dependent: :nullify' do
+        association = double('association', macro: :has_many, options: { through: :memberships, dependent: :nullify })
+
+        expect(described_class.destroys_on_unlink?(association)).to be false
+      end
+    end
+
+    describe '.destroy_target' do
+      it 'is the far collection for a plain has_many' do
+        association = double('association', klass: Tree, options: {})
+
+        expect(described_class.destroy_target(association)).to eq(Tree)
+      end
+
+      it 'is the join collection for a through association, not the far one' do
+        through_reflection = double('through_reflection', klass: Membership)
+        association = double('association', klass: User, through_reflection: through_reflection, options: { through: :memberships })
+
+        expect(described_class.destroy_target(association)).to eq(Membership)
+      end
     end
   end
 end

--- a/spec/services/forest_liana/has_many_dissociator_spec.rb
+++ b/spec/services/forest_liana/has_many_dissociator_spec.rb
@@ -63,6 +63,14 @@ module ForestLiana
 
         expect(described_class.destroy_target(association)).to eq(Membership)
       end
+
+      it 'falls back to the far collection when the join model is excluded from the schema' do
+        allow(ForestLiana::SchemaUtils).to receive(:model_included?).with(Membership).and_return(false)
+        through_reflection = double('through_reflection', klass: Membership)
+        association = double('association', klass: User, through_reflection: through_reflection, options: { through: :memberships })
+
+        expect(described_class.destroy_target(association)).to eq(User)
+      end
     end
   end
 end

--- a/spec/services/forest_liana/has_many_dissociator_spec.rb
+++ b/spec/services/forest_liana/has_many_dissociator_spec.rb
@@ -1,0 +1,35 @@
+module ForestLiana
+  describe HasManyDissociator do
+    describe '.destroys_on_unlink?' do
+      it 'is true for a has_many with dependent: :destroy' do
+        association = double('association', macro: :has_many, options: { dependent: :destroy })
+
+        expect(described_class.destroys_on_unlink?(association)).to be true
+      end
+
+      it 'is true for a has_many with dependent: :delete_all' do
+        association = double('association', macro: :has_many, options: { dependent: :delete_all })
+
+        expect(described_class.destroys_on_unlink?(association)).to be true
+      end
+
+      it 'is false for a has_many with no dependent option' do
+        association = double('association', macro: :has_many, options: {})
+
+        expect(described_class.destroys_on_unlink?(association)).to be false
+      end
+
+      it 'is false for a has_many with dependent: :nullify' do
+        association = double('association', macro: :has_many, options: { dependent: :nullify })
+
+        expect(described_class.destroys_on_unlink?(association)).to be false
+      end
+
+      it 'is false for has_and_belongs_to_many, even with a dependent option' do
+        association = double('association', macro: :has_and_belongs_to_many, options: { dependent: :destroy })
+
+        expect(described_class.destroys_on_unlink?(association)).to be false
+      end
+    end
+  end
+end

--- a/spec/services/forest_liana/has_many_getter_pagination_spec.rb
+++ b/spec/services/forest_liana/has_many_getter_pagination_spec.rb
@@ -24,6 +24,11 @@ module ForestLiana
     subject { described_class.new(Island, association, params, user) }
 
     before(:each) do
+      # This file exercises SQL shaping, not permissions: without this, the read-permission
+      # guard on filters/sort hits the real permissions API through whatever the process-wide
+      # (file-backed) cache last left behind, rather than the "nothing to check" this file assumes.
+      Rails.cache.write('forest.has_permission', false)
+
       # A has_one declared on the target model that actually returns MANY rows: every tree
       # sharing the island. Eager-loading it turns one tree into N joined rows.
       Tree.class_eval do

--- a/spec/services/forest_liana/resources_getter_spec.rb
+++ b/spec/services/forest_liana/resources_getter_spec.rb
@@ -17,6 +17,13 @@ module ForestLiana
       filters: filters,
     }, user) }
 
+    before(:each) do
+      # This file exercises SQL shaping, not permissions: without this, the read-permission
+      # guard on filters/sort hits the real permissions API through whatever the process-wide
+      # (file-backed) cache last left behind, rather than the "nothing to check" this file assumes.
+      Rails.cache.write('forest.has_permission', false)
+    end
+
     def init_scopes
       ForestLiana::ScopeManager.invalidate_scope_cache(rendering_id)
       allow(ForestLiana::ScopeManager).to receive(:fetch_scopes).and_return(scopes)

--- a/spec/services/forest_liana/schema_adapter_spec.rb
+++ b/spec/services/forest_liana/schema_adapter_spec.rb
@@ -71,7 +71,7 @@ module ForestLiana
           end
 
           expect(collection.fields.map { |field| field[:field] }).to eq(
-            ["created_at", "eponymous_tree", "id", "location", "name", "trees", "updated_at"]
+            ["created_at", "eponymous_tree", "id", "location", "members", "memberships", "name", "trees", "updated_at"]
           )
         end
       end

--- a/spec/services/forest_liana/schema_adapter_spec.rb
+++ b/spec/services/forest_liana/schema_adapter_spec.rb
@@ -71,7 +71,7 @@ module ForestLiana
           end
 
           expect(collection.fields.map { |field| field[:field] }).to eq(
-            ["created_at", "eponymous_tree", "id", "location", "members", "memberships", "name", "trees", "updated_at"]
+            ["created_at", "eponymous_tree", "flag", "id", "location", "members", "memberships", "name", "trees", "updated_at"]
           )
         end
       end

--- a/spec/services/forest_liana/search_query_builder_spec.rb
+++ b/spec/services/forest_liana/search_query_builder_spec.rb
@@ -8,7 +8,7 @@ module ForestLiana
 
     before do
       allow(ForestLiana::ScopeManager)
-        .to receive(:append_scope_for_user)
+        .to receive(:append_scope)
         .and_return(nil)
       allow(ForestLiana)
         .to receive(:schema_for_resource)
@@ -86,6 +86,87 @@ module ForestLiana
           result = builder.perform(Tree.all)
           expect(result.to_sql).to match(/"external_id"\s+=\s+'#{search_uuid}'/i)
         end
+      end
+    end
+
+    describe '#assert_sort_readable!' do
+      let(:params) { { sort: sort } }
+      let(:user) { { 'id' => '1', 'roleId' => 1, 'rendering_id' => 1 } }
+
+      def write_permissions(collection_reads)
+        permissions = collection_reads.to_h do |name, readable|
+          [name, { 'browse' => readable ? [1] : [], 'read' => readable ? [1] : [], 'edit' => [], 'add' => [], 'delete' => [], 'export' => [], :actions => {} }]
+        end
+
+        Rails.cache.write('forest.collections', permissions)
+      end
+
+      before do
+        Rails.cache.write('forest.users', { '1' => user })
+        Rails.cache.write('forest.has_permission', true)
+        builder.perform(Tree.all)
+      end
+
+      context 'sorting on a column of an unreadable relation' do
+        let(:sort) { '-owner.name' }
+
+        it 'refuses, naming the path the sort actually reads' do
+          write_permissions('Tree' => true, 'User' => false)
+
+          expect { builder.assert_sort_readable!(user, Tree) }.to raise_error(
+            ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError,
+            "You cannot sort on 'owner:name': you are not allowed to read the 'User' collection."
+          )
+        end
+
+        it 'is served once the relation is readable' do
+          write_permissions('Tree' => true, 'User' => true)
+
+          expect { builder.assert_sort_readable!(user, Tree) }.not_to raise_error
+        end
+      end
+
+      context 'sorting on a path crossing two relations' do
+        # detect_reference's own `ref, field = param.split('.')` only ever resolves the first two
+        # segments; the guard checks exactly that, not the segment the query never reaches.
+        let(:sort) { '-owner.name.extra' }
+
+        it 'checks the same two segments detect_reference resolves, not the dropped third one' do
+          write_permissions('Tree' => true, 'User' => false)
+
+          expect { builder.assert_sort_readable!(user, Tree) }.to raise_error(
+            ForestLiana::Ability::Exceptions::UnauthorizedQueryFieldError,
+            "You cannot sort on 'owner:name': you are not allowed to read the 'User' collection."
+          )
+        end
+      end
+    end
+
+    describe 'the tree it authorizes' do
+      let(:raw_filter) { { 'field' => 'name', 'operator' => 'equal', 'value' => 'Oak' } }
+      let(:params) { { filters: JSON.generate(raw_filter) } }
+
+      before do
+        Rails.cache.write('forest.has_permission', false)
+        allow(ForestLiana::ScopeManager).to receive(:append_scope).and_call_original
+        allow(ForestLiana::ScopeManager).to receive(:get_scope).and_return(nil)
+      end
+
+      # The path guard reads `ScopeManager.inject_context_variables(@params[:filters], @user)`
+      # once and hands that same object on to `append_scope`/`FiltersParser` — proving the tree
+      # FiltersParser applies is identical to the one the guard read, not a second, independent
+      # parse of the same query string that could drift from it.
+      it 'hands FiltersParser exactly what it authorized, byte for byte' do
+        expected_tree = ForestLiana::ScopeManager.inject_context_variables(params[:filters], user)
+        received_tree = nil
+        allow(FiltersParser).to receive(:new).and_wrap_original do |original, filters, *rest|
+          received_tree = filters
+          original.call(filters, *rest)
+        end
+
+        builder.perform(Tree.all)
+
+        expect(received_tree).to eq(expected_tree)
       end
     end
   end

--- a/spec/services/forest_liana/search_query_builder_spec.rb
+++ b/spec/services/forest_liana/search_query_builder_spec.rb
@@ -94,16 +94,29 @@ module ForestLiana
       let(:user) { { 'id' => '1', 'roleId' => 1, 'rendering_id' => 1 } }
 
       def write_permissions(collection_reads)
-        permissions = collection_reads.to_h do |name, readable|
-          [name, { 'browse' => readable ? [1] : [], 'read' => readable ? [1] : [], 'edit' => [], 'add' => [], 'delete' => [], 'export' => [], :actions => {} }]
+        raw_collections = collection_reads.to_h do |name, readable|
+          enabled = { 'roles' => readable ? [1] : [] }
+          disabled = { 'roles' => [] }
+          [name, {
+            'collection' => {
+              'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => disabled,
+              'addEnabled' => disabled, 'deleteEnabled' => disabled, 'exportEnabled' => disabled
+            },
+            'actions' => {}
+          }]
         end
 
-        Rails.cache.write('forest.collections', permissions)
+        # read_permissions may force a real refetch on a denial (a stale cache may sit behind a
+        # just-granted permission) — stub the source instead of writing the derived cache directly,
+        # so that refetch sees the same permissions rather than hitting the network.
+        allow_any_instance_of(ForestLiana::Ability::Fetch).to receive(:get_permissions)
+          .with('/liana/v4/permissions/environment').and_return('collections' => raw_collections)
       end
 
       before do
         Rails.cache.write('forest.users', { '1' => user })
         Rails.cache.write('forest.has_permission', true)
+        Rails.cache.delete('forest.collections') # force a fresh fetch through the stub below, not a leftover from an earlier example
         builder.perform(Tree.all)
       end
 


### PR DESCRIPTION
fixes PRD-1084

Depends on #794 (PRD-1081) and #795 (PRD-1083, `redact_fields`/the "named vs default" pattern this ticket mirrors for refusal instead of redaction) — branched from #795, not mergeable on its own until those two land; the diff below includes their commits until then.

## Why

Redacting the response (#795) is not enough: a filter on a column of a collection the role cannot read leaks its value without ever returning it — a `starts_with` answers one guess per request, read off whether rows come back — and a sort on such a column silently reorders the page by it. Both leak the value they touch, so this guard always **refuses**, never redacts: dropping a filter condition widens the result set and dropping a sort clause silently reorders it.

## What

`Ability::Permission#assert_can_read_query_fields` resolves each filter/sort path to its leaf collection (`FieldPath`, #794) and refuses on the first unreadable one, naming the path and the collection. The root collection is pinned readable — already gated upstream by `browse`/`read` — and the agent-injected scope is never checked, only the caller's own filter tree.

The two are wired differently, following where each is actually parsed:

* **Filters** are checked inside `SearchQueryBuilder#perform`, the single funnel both getters build `@records` through (list, count, csv, related, and destroy_bulk/select-all) — so filters are refused on every one of those routes alike, count included.
* **Sort** turned out to be parsed inside the getters' own *constructors* (`prepare_query`), identically whether the caller asked for `index` or `count` — there is no perform/count branch to hook at that layer. `sort_query` now only records the paths it resolves; a separate `assert_sort_readable!` checks them, called explicitly by `ResourcesGetter#perform`/`HasManyGetter#perform` and deliberately never by `count`, which never applies the sort anyway (Rails strips the ORDER BY from the emitted COUNT SQL on its own).

`ScopeManager.append_scope_for_user` is split into `append_scope` (merges an already-injected filter with the scope) so the caller-only tree can be read once, checked, and handed on unchanged — the guard authorizes the exact object `FiltersParser` applies, not a second, independent parse that could drift from it. Calling `append_scope_for_user` a second time on an already-injected tree isn't safe: it re-runs the `{{...}}` placeholder substitution, which raises on a value that merely looks like one.

`UnauthorizedQueryFieldError` (403) is wired into the four routes that build a filtered/sorted query: index, count, and their relationships equivalents. **`associations#count` had no `ExpectedError` rescue at all before this** — any denial surfaced as a bodiless 500; it now matches the other three.

A path `FieldPath` cannot resolve is treated differently by design: a filter's is left to raise from `FiltersParser` right after this guard, which already has its own pinned 422 message for it; a sort's has no such downstream validator, so it is left to raise directly from `FieldPath` instead of silently letting a bogus sort through to a 500.

## A pre-existing test-isolation gap this surfaced

Three spec files (`resources_getter_spec.rb`, `has_many_getter_pagination_spec.rb`, and the scoped-action examples in `actions_controller_spec.rb`) construct getters directly and never anticipated any permission-system check running during that — nothing before this guard read `has_permission_system?` outside of `forest_authorize!`, which those specs bypass. The repo's `Rails.cache` is a `FileStore` persisted on disk across separate `bundle exec rspec` invocations, so these files intermittently inherited stale permission state from other spec runs. They now declare "no permission system" explicitly — the same fix `count_spec.rb` already needed for the same reason in #795.

## Not in scope

* The three chart stat-getters share the same `append_scope_for_user` seam but are not covered here, per the ticket.
* `destroy_bulk`/select-all now goes through this guard with no exemption — a deliberate divergence from v2, which carved delete routes out (PRD-1012); here the filter comes from a list view the guard has already authorized once, and `forest_authorize!('delete')` gates the route itself.

## Behavioral change to flag for release notes

`AssociationsController#index`/`#count` now call `forest_authorize!('browse', ...)` on the related collection — previously neither route checked any permission at all (the actual security gap this PR also closes for `update`/`associate`/`dissociate`, added while addressing review feedback). A role that could browse a parent record and see a related list without `browse` on the related collection itself will now get a 403 there. This is the correct target state, but it's a visible behavior change for any existing deployment relying on the old (unauthorized) default.

## Tests

New: `spec/services/forest_liana/ability/assert_can_read_query_fields_spec.rb` (13 unit examples — denial/allow on filter and sort, traversal through an unreadable collection, root pin, polymorphic ×3, smart belongsTo, unresolvable-path asymmetry), `FiltersParser.field_paths` specs, `SearchQueryBuilder#assert_sort_readable!`/tree-fidelity specs, plus new request-level examples in `resources_spec.rb` and `associations_spec.rb` covering index/count/csv, the scope-not-checked and root-pinned cases.

Full suite: 588 examples, 0 failures. Root pin, count-never-checks-sort, and the filter-path-skip-vs-sort-path-raise asymmetry are each mutation-checked (reverting the corresponding line turns the relevant spec red).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse filters and sorts reading unreadable collections in permission checks
> - Adds `ForestLiana::Ability::Permission#assert_can_read_query_fields`, which resolves filter and sort field paths to their target collections and raises `UnauthorizedQueryFieldError` (HTTP 403) when any leaf collection is not readable
> - Wires the check into `SearchQueryBuilder#perform` for caller filters and into `assert_sort_readable!` on `ResourcesGetter` and `HasManyGetter` so index, count, CSV, and association listing all enforce it
> - Adds association write authorization in `AssociationsController`: edit permission on the write target for associate/update, and delete permission when dissociation or has_one replacement destroys records (`BelongsToUpdater.replaces_destructively?`, `HasManyDissociator.destroys_on_unlink?`)
> - Extracts scope composition into `ScopeManager.append_scope` so the caller filter is context-injected once before scope appending
> - Fixes malformed aggregator handling: non-Array `conditions` values in `FiltersParser` and `ContextVariablesInjector` now raise HTTP 422 instead of iterating the invalid shape
> - Risk: requests that previously sorted or filtered through an unreadable related collection now return 403; `ResourcesGetter.initialize_resources_getter` applies the sort check during construction so `get_ids_from_request` paths are also covered — verify no internal callers depend on sorting through unreadable relations
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #796 opened
>
> - Added request-level validation to reject non-Hash top-level filters with a 422 status code and error message 'Filters cannot be a raw value' [8735ad3]
> - Added type guards in `ForestLiana::FiltersParser.field_paths` and `ForestLiana::Utils::ContextVariablesInjector.inject_context_in_filter` to handle non-Hash filter inputs [8735ad3]
> - Added test coverage for non-Hash filter handling in `FiltersParser.field_paths` and resource requests [8735ad3]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b626556.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
