### PR TITLE
feat(capabilities): serve POST /_internal/capabilities [PRD-1080]

### DIFF
--- a/app/controllers/forest_liana/capabilities_controller.rb
+++ b/app/controllers/forest_liana/capabilities_controller.rb
@@ -1,0 +1,13 @@
+module ForestLiana
+  class CapabilitiesController < ForestLiana::ApplicationController
+    def index
+      capabilities = ForestLiana::CapabilitiesGetter.new(params[:collectionNames]).perform
+
+      render serializer: nil, json: capabilities, status: :ok
+    rescue => error
+      FOREST_REPORTER.report error
+      FOREST_LOGGER.error "Error while getting the capabilities: #{error.message}"
+      internal_server_error
+    end
+  end
+end

--- a/app/services/forest_liana/capabilities_getter.rb
+++ b/app/services/forest_liana/capabilities_getter.rb
@@ -1,0 +1,130 @@
+module ForestLiana
+  class CapabilitiesGetter
+    # NOTICE: A flag stays false until the matching behaviour actually ships; the frontend
+    #         turns the feature on for every request as soon as it reads true here.
+    AGENT_CAPABILITIES = {
+      canUseProjectionOnGetOne: false,
+      canUseProjectionViaHeader: false,
+      canUseProjectionViaHeaderOnList: false,
+      canUseMultipleFieldsProjectionOnRelation: false,
+      canUseAuditTrail: false
+    }.freeze
+
+    # NOTICE: LineStatGetter#get_format only knows those four, so a quarterly line chart
+    #         would come back with unlabelled points.
+    SUPPORTED_DATE_OPERATIONS = %w(Day Week Month Year).freeze
+
+    # NOTICE: The announced operators replace the frontend defaults for the field, so this
+    #         has to mirror FiltersParser#parse_operator and OperatorDateIntervalParser:
+    #         announcing more hands the user a filter the agent rejects, announcing less
+    #         removes one that works today.
+    COMMON_OPERATORS = %w(equal not_equal present blank).freeze
+    IN_OPERATOR = %w(in).freeze
+    COMPARISON_OPERATORS = %w(greater_than less_than).freeze
+    STRING_OPERATORS = %w(starts_with ends_with contains i_contains not_contains).freeze
+    DATE_OPERATORS = %w(
+      before after past future today yesterday
+      previous_x_days previous_week previous_month previous_quarter previous_year
+      previous_x_days_to_date previous_week_to_date previous_month_to_date
+      previous_quarter_to_date previous_year_to_date
+      before_x_hours_ago after_x_hours_ago
+    ).freeze
+
+    OPERATORS_PER_TYPE = {
+      'Boolean' => COMMON_OPERATORS,
+      'Date' => COMMON_OPERATORS + DATE_OPERATORS,
+      'Dateonly' => COMMON_OPERATORS + DATE_OPERATORS,
+      'Enum' => COMMON_OPERATORS + IN_OPERATOR,
+      'File' => COMMON_OPERATORS + IN_OPERATOR + STRING_OPERATORS,
+      'Json' => COMMON_OPERATORS,
+      'Number' => COMMON_OPERATORS + IN_OPERATOR + COMPARISON_OPERATORS,
+      'String' => COMMON_OPERATORS + IN_OPERATOR + STRING_OPERATORS,
+      'Time' => COMMON_OPERATORS + COMPARISON_OPERATORS,
+      'Uuid' => COMMON_OPERATORS + IN_OPERATOR
+    }.freeze
+
+    def initialize(collection_names)
+      @collection_names = Array(collection_names).map(&:to_s)
+    end
+
+    # NOTICE: nativeQueryConnections is deliberately absent: announcing connections — even an
+    #         empty list — makes the frontend send live queries to /_internal/native_query,
+    #         which this agent does not serve.
+    def perform
+      {
+        agentCapabilities: AGENT_CAPABILITIES,
+        collections: requested_collections.map { |collection| collection_capabilities(collection) }
+      }
+    end
+
+    private
+
+    def requested_collections
+      ForestLiana.apimap.select do |collection|
+        @collection_names.include?(collection.name.to_s)
+      end
+    end
+
+    def collection_capabilities(collection)
+      fields = collection.fields.map { |field| field_capabilities(field) }.compact
+
+      {
+        name: collection.name.to_s,
+        fields: fields,
+        aggregationCapabilities: {
+          supportGroups: fields.any? { |field| field[:isGroupable] },
+          supportedDateOperations: SUPPORTED_DATE_OPERATIONS
+        }
+      }
+    end
+
+    def field_capabilities(field)
+      return nil unless exposed?(field)
+
+      if belongs_to?(field)
+        {
+          name: field[:field].to_s,
+          type: 'ManyToOne',
+          isGroupable: groupable?(field)
+        }
+      else
+        {
+          name: field[:field].to_s,
+          type: field[:type],
+          operators: operators_for(field),
+          isGroupable: groupable?(field)
+        }
+      end
+    end
+
+    # NOTICE: Only columns and belongsTo relationships carry capabilities, as in the v2 agent.
+    def exposed?(field)
+      field[:relationship].nil? || belongs_to?(field)
+    end
+
+    def belongs_to?(field)
+      field[:relationship].to_s == 'BelongsTo'
+    end
+
+    def polymorphic?(field)
+      field[:polymorphic_referenced_models].present?
+    end
+
+    # NOTICE: Grouping happens in SQL on the collection's own connection, which rules out Smart
+    #         Fields, cross-database belongsTo (left unfilterable by SchemaUtils) and polymorphic
+    #         relations, whose foreign key is meaningless without its type column.
+    def groupable?(field)
+      return false if field[:is_virtual] || polymorphic?(field)
+
+      !!field[:is_filterable]
+    end
+
+    def operators_for(field)
+      return [] unless field[:is_filterable]
+      # NOTICE: Array columns would only get includes_all, which FiltersParser does not implement.
+      return [] if field[:type].is_a?(Array)
+
+      OPERATORS_PER_TYPE.fetch(field[:type], COMMON_OPERATORS)
+    end
+  end
+end

--- a/app/services/forest_liana/capabilities_getter.rb
+++ b/app/services/forest_liana/capabilities_getter.rb
@@ -112,9 +112,11 @@ module ForestLiana
 
     # NOTICE: Grouping happens in SQL on the collection's own connection, which rules out Smart
     #         Fields, cross-database belongsTo (left unfilterable by SchemaUtils) and polymorphic
-    #         relations, whose foreign key is meaningless without its type column.
+    #         relations, whose foreign key is meaningless without its type column. A primary key
+    #         is excluded because the frontend never offers it: Field#isGroupable returns false on
+    #         one before it even reads this, so announcing true only inflates supportGroups.
     def groupable?(field)
-      return false if field[:is_virtual] || polymorphic?(field)
+      return false if field[:is_primary_key] || field[:is_virtual] || polymorphic?(field)
 
       !!field[:is_filterable]
     end

--- a/app/services/forest_liana/capabilities_getter.rb
+++ b/app/services/forest_liana/capabilities_getter.rb
@@ -125,6 +125,9 @@ module ForestLiana
     #         one before it even reads this, so announcing true only inflates supportGroups.
     def groupable?(field)
       return false if field[:is_primary_key] || field[:is_virtual] || polymorphic?(field)
+      # NOTICE: The group by reaches the database as a bare column, which a json column has no
+      #         equality operator for — and the schema cannot tell it from a jsonb one.
+      return false if field[:type] == 'Json'
 
       !!field[:is_filterable]
     end

--- a/app/services/forest_liana/capabilities_getter.rb
+++ b/app/services/forest_liana/capabilities_getter.rb
@@ -14,10 +14,12 @@ module ForestLiana
     #         would come back with unlabelled points.
     SUPPORTED_DATE_OPERATIONS = %w(Day Week Month Year).freeze
 
-    # NOTICE: The announced operators replace the frontend defaults for the field, so this
+    # NOTICE: The announced operators are intersected with the frontend's own per-type table,
+    #         never substituted for it, so the announcement can only narrow its defaults. This
     #         has to mirror FiltersParser#parse_operator and OperatorDateIntervalParser:
-    #         announcing more hands the user a filter the agent rejects, announcing less
-    #         removes one that works today.
+    #         announcing less removes a filter that works today, announcing an operator the
+    #         frontend does not list for that type is a no-op, and announcing one it does list
+    #         but the liana mishandles hands the user a broken filter.
     COMMON_OPERATORS = %w(equal not_equal present blank).freeze
     # NOTICE: FiltersParser compares with a bare `=`, which the database refuses against a
     #         json/jsonb/hstore column, so equality would answer a 500 instead of a filtered list.

--- a/app/services/forest_liana/capabilities_getter.rb
+++ b/app/services/forest_liana/capabilities_getter.rb
@@ -106,8 +106,11 @@ module ForestLiana
       field[:relationship].to_s == 'BelongsTo'
     end
 
+    # NOTICE: A polymorphic relation carries polymorphic_referenced_models, while the two columns
+    #         behind it are declared with polymorphic_key. Neither half is announced groupable:
+    #         the foreign key is meaningless without its type column.
     def polymorphic?(field)
-      field[:polymorphic_referenced_models].present?
+      field[:polymorphic_referenced_models].present? || !!field[:polymorphic_key]
     end
 
     # NOTICE: Grouping happens in SQL on the collection's own connection, which rules out Smart

--- a/app/services/forest_liana/capabilities_getter.rb
+++ b/app/services/forest_liana/capabilities_getter.rb
@@ -134,6 +134,9 @@ module ForestLiana
 
     def operators_for(field)
       return [] unless field[:is_filterable]
+      # NOTICE: FiltersParser answers 501 on a smart field whose declaration carries no
+      #         :filter callback, so announcing an operator would promise a filter that errors.
+      return [] if field[:is_virtual] && field[:filter].nil?
       # NOTICE: Array columns would only get includes_all, which FiltersParser does not implement.
       return [] if field[:type].is_a?(Array)
 

--- a/app/services/forest_liana/capabilities_getter.rb
+++ b/app/services/forest_liana/capabilities_getter.rb
@@ -19,6 +19,9 @@ module ForestLiana
     #         announcing more hands the user a filter the agent rejects, announcing less
     #         removes one that works today.
     COMMON_OPERATORS = %w(equal not_equal present blank).freeze
+    # NOTICE: FiltersParser compares with a bare `=`, which the database refuses against a
+    #         json/jsonb/hstore column, so equality would answer a 500 instead of a filtered list.
+    PRESENCE_OPERATORS = %w(present blank).freeze
     IN_OPERATOR = %w(in).freeze
     COMPARISON_OPERATORS = %w(greater_than less_than).freeze
     STRING_OPERATORS = %w(starts_with ends_with contains i_contains not_contains).freeze
@@ -36,7 +39,7 @@ module ForestLiana
       'Dateonly' => COMMON_OPERATORS + DATE_OPERATORS,
       'Enum' => COMMON_OPERATORS + IN_OPERATOR,
       'File' => COMMON_OPERATORS + IN_OPERATOR + STRING_OPERATORS,
-      'Json' => COMMON_OPERATORS,
+      'Json' => PRESENCE_OPERATORS,
       'Number' => COMMON_OPERATORS + IN_OPERATOR + COMPARISON_OPERATORS,
       'String' => COMMON_OPERATORS + IN_OPERATOR + STRING_OPERATORS,
       'Time' => COMMON_OPERATORS + COMPARISON_OPERATORS,

--- a/app/services/forest_liana/filters_parser.rb
+++ b/app/services/forest_liana/filters_parser.rb
@@ -98,7 +98,7 @@ module ForestLiana
       # NOTICE: Set the integer value instead of a string if "enum" type
       # NOTICE: Rails 3 do not have a defined_enums method
       if current_resource.respond_to?(:defined_enums) && current_resource.defined_enums.has_key?(association_field)
-        value = current_resource.defined_enums[association_field][value]
+        value = map_enum_value(current_resource.defined_enums[association_field], operator, value)
       end
 
       case_insensitive = operator == 'i_contains'
@@ -305,6 +305,16 @@ module ForestLiana
     end
 
     private
+
+    # NOTICE: `in` carries several values, so each one has to be mapped on its own. Mapping the
+    #         whole payload would look up "king,villager" in the enum, find nothing and produce
+    #         an `IN (NULL)` matching no row at all.
+    def map_enum_value(enums, operator, value)
+      return enums[value] unless operator == 'in'
+
+      values = value.is_a?(String) ? value.split(',').map(&:strip) : Array(value)
+      values.map { |item| enums[item] }
+    end
 
     def prepare_value_for_operator(operator, value)
       # parenthesis around the parsed_value are required to make the `IN` operator work

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,9 @@ ForestLiana::Engine.routes.draw do
   # Scopes
   post '/scope-cache-invalidation' => 'scopes#invalidate_scope_cache'
 
+  # Capabilities: what the frontend is allowed to turn on for this agent.
+  post '_internal/capabilities' => 'capabilities#index'
+
   # Workflow executor proxy: single catch-all forwarding every verb/sub-path verbatim.
   # Mounted only when ForestLiana.workflow_executor_url is set.
   if ForestLiana.workflow_executor_url.present?

--- a/spec/requests/capabilities_spec.rb
+++ b/spec/requests/capabilities_spec.rb
@@ -1,0 +1,174 @@
+require 'rails_helper'
+require 'json'
+
+describe 'Capabilities', type: :request do
+  let(:token) do
+    JWT.encode(
+      {
+        id: 1,
+        email: 'michael.kelso@that70.show',
+        first_name: 'Michael',
+        last_name: 'Kelso',
+        team: 'Operations',
+        rendering_id: '13',
+        exp: Time.now.to_i + 2.weeks.to_i,
+        permission_level: 'admin'
+      },
+      ForestLiana.auth_secret,
+      'HS256'
+    )
+  end
+  let(:headers) do
+    {
+      'Accept' => 'application/json',
+      'Content-Type' => 'application/json',
+      'Authorization' => "Bearer #{token}"
+    }
+  end
+
+  before do
+    allow(ForestLiana::IpWhitelist).to receive(:retrieve) { true }
+    allow(ForestLiana::IpWhitelist).to receive(:is_ip_whitelist_retrieved) { true }
+    allow(ForestLiana::IpWhitelist).to receive(:is_ip_valid) { true }
+  end
+
+  def fetch_capabilities(collection_names)
+    post '/forest/_internal/capabilities',
+      params: { collectionNames: collection_names }.to_json,
+      headers: headers
+
+    JSON.parse(response.body)
+  end
+
+  def field(body, collection_name, field_name)
+    collection = body['collections'].find { |item| item['name'] == collection_name }
+    collection['fields'].find { |item| item['name'] == field_name }
+  end
+
+  describe 'authentication' do
+    it 'rejects a call without a token' do
+      post '/forest/_internal/capabilities',
+        params: { collectionNames: ['Tree'] }.to_json,
+        headers: headers.except('Authorization')
+
+      expect(response.status).to eq(401)
+    end
+  end
+
+  describe 'requested collections' do
+    it 'answers only the requested ones' do
+      body = fetch_capabilities(['Tree'])
+
+      expect(response.status).to eq(200)
+      expect(body['collections'].map { |collection| collection['name'] }).to eq(['Tree'])
+    end
+
+    it 'ignores an unknown collection name' do
+      body = fetch_capabilities(['Tree', 'ThisCollectionDoesNotExist'])
+
+      expect(response.status).to eq(200)
+      expect(body['collections'].map { |collection| collection['name'] }).to eq(['Tree'])
+    end
+
+    it 'answers no collection when none is requested' do
+      body = fetch_capabilities([])
+
+      expect(response.status).to eq(200)
+      expect(body['collections']).to eq([])
+    end
+  end
+
+  describe 'agentCapabilities' do
+    # NOTICE: This liana implements none of the announced behaviours yet; each flag flips
+    #         in the ticket that implements it.
+    it 'announces every flag as false' do
+      body = fetch_capabilities(['Tree'])
+
+      expect(body['agentCapabilities']).to eq(
+        'canUseProjectionOnGetOne' => false,
+        'canUseProjectionViaHeader' => false,
+        'canUseProjectionViaHeaderOnList' => false,
+        'canUseMultipleFieldsProjectionOnRelation' => false,
+        'canUseAuditTrail' => false
+      )
+    end
+  end
+
+  describe 'nativeQueryConnections' do
+    # NOTICE: Announcing connections would make the frontend send live queries to
+    #         /_internal/native_query, which this liana does not serve.
+    it 'is not announced at all' do
+      body = fetch_capabilities(['Tree'])
+
+      expect(body).not_to have_key('nativeQueryConnections')
+    end
+  end
+
+  describe 'fields' do
+    it 'announces a column with the operators the liana implements' do
+      body = fetch_capabilities(['Tree'])
+
+      expect(field(body, 'Tree', 'name')).to eq(
+        'name' => 'name',
+        'type' => 'String',
+        'operators' => %w(
+          equal not_equal present blank in
+          starts_with ends_with contains i_contains not_contains
+        ),
+        'isGroupable' => true
+      )
+      expect(field(body, 'Tree', 'age')['operators'])
+        .to eq(%w(equal not_equal present blank in greater_than less_than))
+      expect(field(body, 'Tree', 'created_at')['operators'])
+        .to include('previous_quarter_to_date', 'before_x_hours_ago')
+    end
+
+    it 'announces a belongsTo as a ManyToOne groupable off its foreign key column' do
+      body = fetch_capabilities(['Tree'])
+
+      expect(field(body, 'Tree', 'owner')).to eq(
+        'name' => 'owner',
+        'type' => 'ManyToOne',
+        'isGroupable' => true
+      )
+    end
+
+    it 'leaves out the relationships that carry no capability' do
+      body = fetch_capabilities(['Tree'])
+
+      expect(field(body, 'Tree', 'location')).to be_nil
+    end
+
+    it 'announces a polymorphic relation without claiming it is groupable' do
+      body = fetch_capabilities(['Address'])
+
+      expect(field(body, 'Address', 'addressable')).to eq(
+        'name' => 'addressable',
+        'type' => 'ManyToOne',
+        'isGroupable' => false
+      )
+    end
+
+    it 'announces no operator on a field the liana cannot filter' do
+      body = fetch_capabilities(['Address'])
+
+      expect(field(body, 'Address', 'address_type')).to eq(
+        'name' => 'address_type',
+        'type' => 'String',
+        'operators' => [],
+        'isGroupable' => false
+      )
+    end
+  end
+
+  describe 'aggregationCapabilities' do
+    it 'announces the time ranges the liana can label' do
+      body = fetch_capabilities(['Tree'])
+
+      expect(body['collections'].first['aggregationCapabilities']).to eq(
+        'supportGroups' => true,
+        'supportedDateOperations' => %w(Day Week Month Year)
+      )
+    end
+  end
+end

--- a/spec/requests/capabilities_spec.rb
+++ b/spec/requests/capabilities_spec.rb
@@ -149,6 +149,19 @@ describe 'Capabilities', type: :request do
       )
     end
 
+    # NOTICE: Field#isGroupable returns false on a primary key before it reads the announcement,
+    #         so claiming true here would only inflate supportGroups.
+    it 'announces the primary key as not groupable' do
+      body = fetch_capabilities(['Tree'])
+
+      expect(field(body, 'Tree', 'id')).to eq(
+        'name' => 'id',
+        'type' => 'Number',
+        'operators' => %w(equal not_equal present blank in greater_than less_than),
+        'isGroupable' => false
+      )
+    end
+
     it 'announces no operator on a field the liana cannot filter' do
       body = fetch_capabilities(['Address'])
 

--- a/spec/requests/capabilities_spec.rb
+++ b/spec/requests/capabilities_spec.rb
@@ -194,8 +194,8 @@ describe 'Capabilities', type: :request do
     end
   end
 
-  # NOTICE: SQLite has no array column, and every collection of the dummy app has at least one
-  #         groupable field, so both cases are announced off a stubbed apimap.
+  # NOTICE: SQLite has neither an array nor a json column, and every collection of the dummy app
+  #         has at least one groupable field, so those cases are announced off a stubbed apimap.
   describe 'a schema the dummy app cannot express' do
     def collection(name, fields)
       ForestLiana::Model::Collection.new(name: name, fields: fields)
@@ -206,6 +206,10 @@ describe 'Capabilities', type: :request do
         collection('WithAnArrayColumn', [
           { field: 'id', type: 'Number', is_primary_key: true },
           { field: 'tags', type: ['String'] }
+        ]),
+        collection('WithAJsonColumn', [
+          { field: 'id', type: 'Number', is_primary_key: true },
+          { field: 'payload', type: 'Json' }
         ]),
         collection('WithNothingGroupable', [
           { field: 'id', type: 'Number', is_primary_key: true },
@@ -223,6 +227,18 @@ describe 'Capabilities', type: :request do
         'name' => 'tags',
         'type' => ['String'],
         'operators' => [],
+        'isGroupable' => true
+      )
+    end
+
+    # NOTICE: An equality on a json column reaches the database as a bare `=`, which it refuses.
+    it 'announces only the presence operators on a json column' do
+      body = fetch_capabilities(['WithAJsonColumn'])
+
+      expect(field(body, 'WithAJsonColumn', 'payload')).to eq(
+        'name' => 'payload',
+        'type' => 'Json',
+        'operators' => %w(present blank),
         'isGroupable' => true
       )
     end

--- a/spec/requests/capabilities_spec.rb
+++ b/spec/requests/capabilities_spec.rb
@@ -194,8 +194,9 @@ describe 'Capabilities', type: :request do
     end
   end
 
-  # NOTICE: SQLite has neither an array nor a json column, and every collection of the dummy app
-  #         has at least one groupable field, so those cases are announced off a stubbed apimap.
+  # NOTICE: SQLite has neither an array nor a json column, every collection of the dummy app has
+  #         at least one groupable field, and none declares a filterable Smart Field, so those
+  #         cases are announced off a stubbed apimap.
   describe 'a schema the dummy app cannot express' do
     def collection(name, fields)
       ForestLiana::Model::Collection.new(name: name, fields: fields)
@@ -214,6 +215,11 @@ describe 'Capabilities', type: :request do
         collection('WithNothingGroupable', [
           { field: 'id', type: 'Number', is_primary_key: true },
           { field: 'computed', type: 'String', is_virtual: true }
+        ]),
+        collection('WithSmartFields', [
+          { field: 'id', type: 'Number', is_primary_key: true },
+          { field: 'computed', type: 'String', is_virtual: true },
+          { field: 'filtered', type: 'String', is_virtual: true, filter: ->(condition, where) { where } }
         ])
       ])
     end
@@ -240,6 +246,32 @@ describe 'Capabilities', type: :request do
         'name' => 'payload',
         'type' => 'Json',
         'operators' => %w(present blank),
+        'isGroupable' => false
+      )
+    end
+
+    # NOTICE: FiltersParser answers 501 on a smart field declared without a :filter callback.
+    it 'announces no operator on a smart field that cannot be filtered' do
+      body = fetch_capabilities(['WithSmartFields'])
+
+      expect(field(body, 'WithSmartFields', 'computed')).to eq(
+        'name' => 'computed',
+        'type' => 'String',
+        'operators' => [],
+        'isGroupable' => false
+      )
+    end
+
+    it 'announces the operators of a smart field carrying a filter callback' do
+      body = fetch_capabilities(['WithSmartFields'])
+
+      expect(field(body, 'WithSmartFields', 'filtered')).to eq(
+        'name' => 'filtered',
+        'type' => 'String',
+        'operators' => %w(
+          equal not_equal present blank in
+          starts_with ends_with contains i_contains not_contains
+        ),
         'isGroupable' => false
       )
     end

--- a/spec/requests/capabilities_spec.rb
+++ b/spec/requests/capabilities_spec.rb
@@ -231,15 +231,16 @@ describe 'Capabilities', type: :request do
       )
     end
 
-    # NOTICE: An equality on a json column reaches the database as a bare `=`, which it refuses.
-    it 'announces only the presence operators on a json column' do
+    # NOTICE: Both an equality and a group by reach a json column as a bare column, which the
+    #         database has no equality operator for, and the schema cannot tell it from a jsonb.
+    it 'announces a json column on presence only, and not groupable' do
       body = fetch_capabilities(['WithAJsonColumn'])
 
       expect(field(body, 'WithAJsonColumn', 'payload')).to eq(
         'name' => 'payload',
         'type' => 'Json',
         'operators' => %w(present blank),
-        'isGroupable' => true
+        'isGroupable' => false
       )
     end
 

--- a/spec/requests/capabilities_spec.rb
+++ b/spec/requests/capabilities_spec.rb
@@ -149,6 +149,15 @@ describe 'Capabilities', type: :request do
       )
     end
 
+    # NOTICE: Both columns behind the relation are declared with polymorphic_key, and neither
+    #         groups on its own — the foreign key needs its type column to mean anything.
+    it 'announces the columns behind it as not groupable either' do
+      body = fetch_capabilities(['Address'])
+
+      expect(field(body, 'Address', 'addressable_id')['isGroupable']).to eq(false)
+      expect(field(body, 'Address', 'addressable_type')['isGroupable']).to eq(false)
+    end
+
     # NOTICE: Field#isGroupable returns false on a primary key before it reads the announcement,
     #         so claiming true here would only inflate supportGroups.
     it 'announces the primary key as not groupable' do
@@ -180,6 +189,49 @@ describe 'Capabilities', type: :request do
 
       expect(body['collections'].first['aggregationCapabilities']).to eq(
         'supportGroups' => true,
+        'supportedDateOperations' => %w(Day Week Month Year)
+      )
+    end
+  end
+
+  # NOTICE: SQLite has no array column, and every collection of the dummy app has at least one
+  #         groupable field, so both cases are announced off a stubbed apimap.
+  describe 'a schema the dummy app cannot express' do
+    def collection(name, fields)
+      ForestLiana::Model::Collection.new(name: name, fields: fields)
+    end
+
+    before do
+      allow(ForestLiana).to receive(:apimap).and_return([
+        collection('WithAnArrayColumn', [
+          { field: 'id', type: 'Number', is_primary_key: true },
+          { field: 'tags', type: ['String'] }
+        ]),
+        collection('WithNothingGroupable', [
+          { field: 'id', type: 'Number', is_primary_key: true },
+          { field: 'computed', type: 'String', is_virtual: true }
+        ])
+      ])
+    end
+
+    # NOTICE: includes_all is the only operator the frontend offers on an array, and
+    #         FiltersParser does not implement it.
+    it 'announces no operator on an array column' do
+      body = fetch_capabilities(['WithAnArrayColumn'])
+
+      expect(field(body, 'WithAnArrayColumn', 'tags')).to eq(
+        'name' => 'tags',
+        'type' => ['String'],
+        'operators' => [],
+        'isGroupable' => true
+      )
+    end
+
+    it 'announces no group support when nothing is groupable' do
+      body = fetch_capabilities(['WithNothingGroupable'])
+
+      expect(body['collections'].first['aggregationCapabilities']).to eq(
+        'supportGroups' => false,
         'supportedDateOperations' => %w(Day Week Month Year)
       )
     end

--- a/spec/services/forest_liana/filters_parser_spec.rb
+++ b/spec/services/forest_liana/filters_parser_spec.rb
@@ -117,6 +117,32 @@ module ForestLiana
             let(:filters) { { 'field' => 'cutter_id', 'operator' => 'blank', 'value' => nil } }
             it { expect(parsed_filters.count).to eq 2 }
           end
+
+          context 'in on a Rails enum column' do
+            # The enum mapping has to happen value by value: looking the whole payload up in
+            # the enum would find nothing and produce an `IN (NULL)` matching no row.
+            let(:resource) { User }
+
+            context 'on a comma separated list' do
+              let(:filters) { { 'field' => 'title', 'operator' => 'in', 'value' => 'king,villager' } }
+              it { expect(parsed_filters.map(&:title)).to match_array(%w(king villager)) }
+            end
+
+            context 'on an array' do
+              let(:filters) { { 'field' => 'title', 'operator' => 'in', 'value' => ['villager'] } }
+              it { expect(parsed_filters.map(&:title)).to eq(['villager']) }
+            end
+
+            context 'on a single value' do
+              let(:filters) { { 'field' => 'title', 'operator' => 'in', 'value' => 'king' } }
+              it { expect(parsed_filters.map(&:title)).to eq(['king']) }
+            end
+
+            context 'on an unknown enum value' do
+              let(:filters) { { 'field' => 'title', 'operator' => 'in', 'value' => 'not_a_title' } }
+              it { expect(parsed_filters.count).to eq 0 }
+            end
+          end
         end
 
         context 'belongsTo conditions' do


### PR DESCRIPTION
Adds `POST /_internal/capabilities` so the frontend can stop assuming the oldest behaviour for this liana. Answers the same shape as the v2 agent (`packages/agent/src/routes/capabilities.ts`), for the requested collections only.

Linear: [PRD-1080](https://linear.app/forestadmin/issue/PRD-1080/v1-serve-the-capabilities-endpoint-so-the-front-can-turn-the-rest-on)

## What it answers

- `agentCapabilities`: the five flags, **all `false`** — nothing announced here is implemented yet, and a spec locks that so a flag can only flip in the PR that implements its behaviour.
- `nativeQueryConnections`: **deliberately absent**. Announcing connections — even an empty list — makes the frontend route live queries to `/_internal/native_query`, which this liana does not serve, and ask for a connection name from an empty list. An absent key is what leaves live-query charts on their current path.
- `collections[]`: only the requested names, with per-field `name`, `type`, `operators`, `isGroupable`, plus the collection's `aggregationCapabilities`.

## Decisions worth reviewing

- **`operators` is announced even though the reference route derives it from per-field filter operators we do not have.** It is not optional: the frontend intersects the announced list with its own per-type table — `OPERATORS_CAPABILITIES_PER_TYPE[type]?.filter(({ name }) => operators.includes(name))` — so wherever that table knows the type, a missing key dereferences `undefined` and throws, and since the flags are committed only after `handleCollections` returns, the whole payload — flags included — is discarded. Being an intersection, the announcement can only narrow the frontend defaults, never extend them, so it mirrors `FiltersParser#parse_operator` and `OperatorDateIntervalParser`: announcing less removes a filter that works today; announcing an operator the front does not list for that type is a no-op; announcing one it *does* list but the agent mishandles hands the user a broken filter — which is exactly what the `Enum` + `in` fix below is about.
- **Only columns and `BelongsTo` carry capabilities**, as in v2 (which keeps `Column` and `ManyToOne` and drops the rest). A `BelongsTo` is announced as `ManyToOne`, and its `isGroupable` comes from the foreign key column for free: `SchemaAdapter#add_associations` renames the FK column entry in place, so in this schema the relation field *is* that column.
- **A polymorphic relation is announced with `isGroupable: false`, not with the key omitted.** Omitting it is not neutral — the frontend falls back to `!isRelationship || isBelongsTo` and would conclude `true`, offering a grouping this agent cannot run since the foreign key is meaningless without its type column.
- **A `Json` column is announced `isGroupable: false`** for the same reason its only operators are `present`/`blank`: `PieStatGetter` groups on the bare column, and a PostgreSQL `json` has no equality operator, so the `GROUP BY` fails. `SchemaAdapter#get_type_for` collapses `json`, `jsonb` and `hstore` into one `Json` type, so the case that would group cannot be told apart. Array columns stay groupable — their `GROUP BY` does run.
- **`operators: []` where the schema says `is_filterable: false`** (Smart Fields, cross-database `BelongsTo`); for array columns, whose only operator would be `includes_all` — which `FiltersParser` does not implement, so today the filter leaves and fails server-side; and for a Smart Field whose declaration carries no `:filter` callback, which `FiltersParser` answers with a 501. A Smart Field that does carry one keeps the operators of its type.
- **`supportedDateOperations` leaves out `Quarter`**, which v2 announces: `LineStatGetter#get_format` knows Day/Week/Month/Year only, so a quarterly line chart would come back with unlabelled points. `supportGroups` is computed from the fields actually groupable, minus the primary key: `Field#isGroupable` returns false on a primary key before it ever reads the announcement, so counting it — as v2 does — advertises grouping on a collection that then offers an empty group-by list.

## Two fixes found while checking the announcement

Announcing an operator is a promise, so every announced operator was replayed through `FiltersParser`. Two promises did not hold:

- **`fix(filters): map enum values one by one for the in operator`** — `parse_condition` mapped the whole payload through `defined_enums[field][value]`, so an `in` filter carrying `king,villager` looked that string up in the enum, found nothing, and produced `WHERE "users"."title" IN (NULL)`: zero rows, no error. The bug predates this endpoint and is independent of it — the frontend has always offered `is in` on an `Enum` field — but announcing `in` here turns it into a promise, so it is fixed rather than dropped. Dropping `in` from `Enum` would have removed it from STI columns too, where it works.
- **`fix(capabilities): exclude the primary key from groupability`** — see the `supportGroups` note above.

## Route and access

Mounted next to the other `_internal` route, and inherits `ApplicationController`, so the JWT check and the IP whitelist apply exactly as they do on the sibling internal routes — an unauthenticated call gets a 401, asserted by a spec.

## Tests

`bundle exec rspec` — 534 examples, 0 failures, including 23 new ones.

Capabilities (19): requested subset, unknown collection name ignored, empty request, the flags-are-false lock, absence of `nativeQueryConnections`, operators per type, `BelongsTo` as a groupable `ManyToOne`, relationships left out, polymorphic relation not groupable, the two key columns behind it not groupable either, primary key not groupable, a field with no operator, an array column, a json column filterable on presence only and not groupable, a Smart Field without a `:filter` callback announcing no operator, one with a callback keeping the operators of its type, `aggregationCapabilities`, a collection with nothing groupable, and the 401.

Filters (4): `in` on a Rails enum column, over a comma separated list, an array, a single value, and a value absent from the enum.

Manually exercised against the dummy app through a real request stack (routing, controller, JWT), on a collection carrying a polymorphic relation and a Smart Field.

## Follow-up outside this PR

The frontend gates the call on `FeaturesEnum.Capabilities`, whose version map has no `forest-rails` entry yet, so nothing calls this route until the frontend adds one (PRD-1087). Two things are worth settling before that happens:

- **`Field#supportedOperators` returns `undefined` for any type absent from `OPERATORS_CAPABILITIES_PER_TYPE`.** That table has no entry for `ManyToOne`, `Json`, `Point` or `Binary`, nor for the v1-only `File`. The lookup in `capabilities.ts` is optional-chained, so nothing throws — the `field-capabilities` record is simply created with `operators: undefined`, and `field.ts` returns that without falling back on `super.supportedOperators`. The unguarded `.some` / `.find` call sites in the workflow editor and the browser extension then dereference it. This hits v2 agents just as hard (every `ManyToOne`, every `Json` column), so the fix belongs on the frontend rather than being worked around here, and it should land on PRD-1087 before the flags flip.
- `canUseProjectionViaHeaderOnList` recently became a composite term on the frontend and now also gates projection pruning by read permission — noted on PRD-1082, which owns those flags.

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made

The route is private and rejects an unauthenticated call. It exposes schema metadata only — field names, types, operators, groupability — for the collections the caller names, which the caller already receives in the apimap; no record data and no configuration secret leaves through it. Every announced flag is `false`, so this cannot make the frontend turn on a behaviour the agent does not have.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `POST /_internal/capabilities` endpoint and fix enum `in` filter parsing
> - Adds `ForestLiana::CapabilitiesController` and `ForestLiana::CapabilitiesGetter` to return agent capability flags, field-level operators, and groupability metadata for requested collections. Only known, requested collections are included; non-BelongsTo relationships are omitted from the response.
> - Adds the route in [routes.rb](https://github.com/ForestAdmin/forest-rails/pull/798/files#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5) dispatching `POST _internal/capabilities` to the new controller.
> - Fixes `FiltersParser#parse_condition` so the enum `in` operator converts each supplied value individually (comma-separated strings or arrays) instead of treating the whole payload as a single enum key. Other enum operators retain single-value conversion.
> - Risk: `CapabilitiesGetter#operators_for` returns no operators for array-typed and non-filterable fields; consumers relying on operator availability for these field types will see empty operator lists.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #798 opened
>
> - Modified `ForestLiana::CapabilitiesGetter#groupable?` to return false for fields with type `Json` [b7738e4]
> - Modified `ForestLiana::CapabilitiesGetter#operators_for` to return an empty operator list for virtual fields without filter callbacks [b7738e4]
> - Extended test coverage for capabilities endpoint to verify Json field groupability, smart field operator behavior, and existing scenarios [b7738e4]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa3a2c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

