### PR TITLE
fix(csv): check read permission on a caller-named field before exporting

### DIFF
--- a/app/controllers/forest_liana/application_controller.rb
+++ b/app/controllers/forest_liana/application_controller.rb
@@ -208,10 +208,11 @@ module ForestLiana
     end
 
     def render_csv getter, model
-      # Every column here is caller-named (params[:fields] is required above), never a default
-      # expansion, so an unreadable one always refuses rather than being silently dropped.
+      # Every column reaching CSV::Row below is caller-named — params[:fields] is required by
+      # the CSV writer itself a few lines down, never defaulted — so an unreadable one always
+      # refuses rather than being silently dropped.
       requested_fields = fields_per_model(params[:fields], model)
-      fields_to_serialize = redact_fields(forest_user, model, requested_fields, named_collections: requested_fields.keys)
+      fields_to_serialize = redact_fields(forest_user, model, requested_fields, named_collections: requested_fields&.keys || [])
 
       set_headers_file
       set_headers_streaming

--- a/app/controllers/forest_liana/application_controller.rb
+++ b/app/controllers/forest_liana/application_controller.rb
@@ -208,19 +208,27 @@ module ForestLiana
     end
 
     def render_csv getter, model
-      # Every column reaching CSV::Row below is caller-named — params[:fields] is required by
-      # the CSV writer itself a few lines down, never defaulted — so an unreadable one always
-      # refuses rather than being silently dropped.
+      # Unlike index/show/update, an unreadable column here is dropped rather than refusing the
+      # whole export (named_collections: [] — nothing is ever "named") — matching agent-nodejs's
+      # own CSV route, which runs the same redactProjection as its JSON list but drops a denied
+      # column instead of 403ing the file whenever it doesn't error there either.
       requested_fields = fields_per_model(params[:fields], model)
-      fields_to_serialize = redact_fields(forest_user, model, requested_fields, named_collections: requested_fields&.keys || [])
+      fields_to_serialize = redact_fields(forest_user, model, requested_fields, named_collections: [])
 
       set_headers_file
       set_headers_streaming
 
       response.status = 200
-      csv_header = params[:header].split(',')
       collection_name = ForestLiana.name_for(model)
-      field_names_requested = params[:fields][collection_name].split(',').map { |name| name.to_s }
+      requested_field_names = params[:fields][collection_name].split(',').map { |name| name.to_s }
+      requested_header = params[:header].split(',')
+
+      # Keep the header row aligned with whatever redact_fields left in fields_to_serialize,
+      # the same way agent-nodejs's CsvGenerator.filterHeader drops a redacted column's label.
+      surviving = (fields_to_serialize[collection_name] || '').split(',')
+      kept = requested_field_names.zip(requested_header).select { |name, _| surviving.include?(name) }
+      field_names_requested = kept.map(&:first)
+      csv_header = kept.map(&:last)
 
       self.response_body = Enumerator.new do |content|
         content << ::CSV::Row.new(field_names_requested, csv_header, true).to_s

--- a/app/controllers/forest_liana/application_controller.rb
+++ b/app/controllers/forest_liana/application_controller.rb
@@ -208,6 +208,11 @@ module ForestLiana
     end
 
     def render_csv getter, model
+      # Every column here is caller-named (params[:fields] is required above), never a default
+      # expansion, so an unreadable one always refuses rather than being silently dropped.
+      requested_fields = fields_per_model(params[:fields], model)
+      fields_to_serialize = redact_fields(forest_user, model, requested_fields, named_collections: requested_fields.keys)
+
       set_headers_file
       set_headers_streaming
 
@@ -215,7 +220,6 @@ module ForestLiana
       csv_header = params[:header].split(',')
       collection_name = ForestLiana.name_for(model)
       field_names_requested = params[:fields][collection_name].split(',').map { |name| name.to_s }
-      fields_to_serialize = fields_per_model(params[:fields], model)
 
       self.response_body = Enumerator.new do |content|
         content << ::CSV::Row.new(field_names_requested, csv_header, true).to_s

--- a/app/controllers/forest_liana/associations_controller.rb
+++ b/app/controllers/forest_liana/associations_controller.rb
@@ -20,12 +20,16 @@ module ForestLiana
           format.csv { render_csv(getter, @association.klass) }
         end
       rescue ForestLiana::Ability::Exceptions::UnauthorizedFieldsError => error
+        # A CSV request already has its response Content-Type/Content-Disposition set by the
+        # respond_to format match before this rescue ever runs — force JSON back, or the client
+        # downloads a ".csv" file whose content is this JSON error.
         render(serializer: nil, json: { errors: [{
           status: error.error_code,
           detail: error.message,
           name: error.name,
           data: error.data
-        }] }, status: error.status)
+        }] }, status: error.status, content_type: 'application/json')
+        response.headers.delete('Content-Disposition')
       rescue ForestLiana::Errors::ExpectedError => error
         error.display_error
         error_data = ForestAdmin::JSONAPI::Serializer.serialize_errors([{

--- a/app/controllers/forest_liana/resources_controller.rb
+++ b/app/controllers/forest_liana/resources_controller.rb
@@ -28,12 +28,16 @@ module ForestLiana
         render json: { errors: [{ status: 422, detail: error.message }] },
           status: :unprocessable_entity, serializer: nil
       rescue ForestLiana::Ability::Exceptions::UnauthorizedFieldsError => error
+        # A CSV request already has its response Content-Type/Content-Disposition set by the
+        # respond_to format match before this rescue ever runs — force JSON back, or the client
+        # downloads a ".csv" file whose content is this JSON error.
         render(serializer: nil, json: { errors: [{
           status: error.error_code,
           detail: error.message,
           name: error.name,
           data: error.data
-        }] }, status: error.status)
+        }] }, status: error.status, content_type: 'application/json')
+        response.headers.delete('Content-Disposition')
       rescue ForestLiana::Errors::ExpectedError => error
         error.display_error
         error_data = ForestAdmin::JSONAPI::Serializer.serialize_errors([{

--- a/app/services/forest_liana/ability/exceptions/unauthorized_fields_error.rb
+++ b/app/services/forest_liana/ability/exceptions/unauthorized_fields_error.rb
@@ -6,6 +6,9 @@ module ForestLiana
 
         def initialize(denied_fields, backtrace = nil)
           @data = { fields: denied_fields.map { |denied| denied[:path] } }
+
+          # Same per-field "from the 'X' collection" repetition agent-nodejs uses for this same
+          # case (authorization.ts's redactProjection) — kept for parity rather than grouped.
           fields_description = denied_fields.map do |denied|
             "'#{denied[:display_path] || denied[:path]}' from #{FieldPath.leaf_label(denied[:collections])}"
           end

--- a/app/services/forest_liana/ability/exceptions/unauthorized_fields_error.rb
+++ b/app/services/forest_liana/ability/exceptions/unauthorized_fields_error.rb
@@ -7,7 +7,7 @@ module ForestLiana
         def initialize(denied_fields, backtrace = nil)
           @data = { fields: denied_fields.map { |denied| denied[:path] } }
           fields_description = denied_fields.map do |denied|
-            "'#{denied[:path]}' from #{FieldPath.leaf_label(denied[:collections])}"
+            "'#{denied[:display_path] || denied[:path]}' from #{FieldPath.leaf_label(denied[:collections])}"
           end
 
           super(

--- a/app/services/forest_liana/ability/permission.rb
+++ b/app/services/forest_liana/ability/permission.rb
@@ -83,6 +83,8 @@ module ForestLiana
       def redact_fields(user, root_model, fields_hash, named_collections:)
         return fields_hash if fields_hash.nil?
 
+        root_name = ForestLiana.name_for(root_model)
+
         resolved = fields_hash.each_with_object({}) do |(collection_key, csv), acc|
           collection_model = SchemaUtils.find_model_from_collection_name(collection_key)
           field_names = csv.to_s.split(',').uniq
@@ -119,7 +121,11 @@ module ForestLiana
               if readable.call(entry[:owners][field_name])
                 true
               else
-                denied << { path: field_name, collections: entry[:owners][field_name] } if named
+                # collection_key is a related entry, not root_model's own fields, whenever it
+                # differs from root_name — prefix the message so it doesn't read as if 'field_name'
+                # were a bare field of the root.
+                display_path = collection_key == root_name ? field_name : "#{collection_key}:#{field_name}"
+                denied << { path: field_name, display_path: display_path, collections: entry[:owners][field_name] } if named
                 false
               end
             end

--- a/spec/requests/associations_spec.rb
+++ b/spec/requests/associations_spec.rb
@@ -81,20 +81,20 @@ describe 'Requesting an association', :type => :request do
     end
   end
 
+  # Unlike index/show/update, an explicitly named but unreadable column drops silently instead
+  # of refusing the whole file — matching agent-nodejs's own CSV route (same redactProjection,
+  # same named-vs-not distinction it already applies to its JSON list, not a CSV-specific rule).
   describe 'csv export, naming a field of a collection the role cannot read' do
-    it 'refuses with a 403 instead of leaking unredacted data' do
+    it 'drops the unreadable column silently instead of refusing the whole export' do
       get "/forest/Island/#{@island.id}/relationships/trees.csv",
           params: { fields: { 'Tree' => 'id,name,owner' }, header: 'id,name,owner' },
           headers: headers
 
-      expect(response.status).to eq(403)
-      # Not a CSV download of the JSON error: respond_to already set these for the matched
-      # format.csv before the rescue ran, so the error render must override them explicitly.
-      expect(response.headers['Content-Type']).to include('application/json')
-      expect(response.headers['Content-Disposition']).to be_nil
-      body = JSON.parse(response.body)
-      expect(body['errors'][0]['detail']).to eq "You are not allowed to read 'owner' from the 'User' collection."
-      expect(body['errors'][0]['data']).to eq('fields' => ['owner'])
+      expect(response.status).to eq(200)
+      expect(response.headers['Content-Type']).to include('text/csv')
+      csv_lines = response.body.split("\n")
+      expect(csv_lines.first).to eq('id,name')
+      expect(csv_lines[1]).to eq('1,Lemon Tree')
     end
   end
 

--- a/spec/requests/associations_spec.rb
+++ b/spec/requests/associations_spec.rb
@@ -80,4 +80,30 @@ describe 'Requesting an association', :type => :request do
       expect(JSON.parse(response.body)['errors'][0]['detail']).to eq "Relation not found: 'Tree.unknown'"
     end
   end
+
+  describe 'csv export, naming a field of a collection the role cannot read' do
+    it 'refuses with a 403 instead of leaking unredacted data' do
+      get "/forest/Island/#{@island.id}/relationships/trees.csv",
+          params: { fields: { 'Tree' => 'id,name,owner' }, header: 'id,name,owner' },
+          headers: headers
+
+      expect(response.status).to eq(403)
+      body = JSON.parse(response.body)
+      expect(body['errors'][0]['detail']).to eq "You are not allowed to read 'owner' from the 'User' collection."
+      expect(body['errors'][0]['data']).to eq('fields' => ['owner'])
+    end
+  end
+
+  describe 'csv export, an ordinary request naming only readable fields' do
+    it 'serves the csv normally' do
+      get "/forest/Island/#{@island.id}/relationships/trees.csv",
+          params: { fields: { 'Tree' => 'id,name' }, header: 'id,name' },
+          headers: headers
+
+      expect(response.status).to eq(200)
+      expect(response.headers['Content-Type']).to include('text/csv')
+      csv_lines = response.body.split("\n")
+      expect(csv_lines[1]).to eq('1,Lemon Tree')
+    end
+  end
 end

--- a/spec/requests/associations_spec.rb
+++ b/spec/requests/associations_spec.rb
@@ -88,6 +88,10 @@ describe 'Requesting an association', :type => :request do
           headers: headers
 
       expect(response.status).to eq(403)
+      # Not a CSV download of the JSON error: respond_to already set these for the matched
+      # format.csv before the rescue ran, so the error render must override them explicitly.
+      expect(response.headers['Content-Type']).to include('application/json')
+      expect(response.headers['Content-Disposition']).to be_nil
       body = JSON.parse(response.body)
       expect(body['errors'][0]['detail']).to eq "You are not allowed to read 'owner' from the 'User' collection."
       expect(body['errors'][0]['data']).to eq('fields' => ['owner'])

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -19,7 +19,8 @@ describe 'Requesting Tree resources', :type => :request  do
       .with('/liana/v4/permissions/environment').and_return(
         'collections' => {
           'Tree' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
-          'Location' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} }
+          'Location' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} },
+          'User' => { 'collection' => { 'browseEnabled' => enabled, 'readEnabled' => enabled, 'editEnabled' => enabled, 'addEnabled' => enabled, 'deleteEnabled' => enabled, 'exportEnabled' => enabled }, 'actions' => {} }
         }
       )
 
@@ -291,6 +292,19 @@ describe 'Requesting Tree resources', :type => :request  do
       expect(csv_lines.first).to eq(params[:header])
       expect(csv_lines[1]).to eq('1,Lemon Tree')
     end
+
+    it 'refuses with a 403 instead of leaking unredacted data for a field of an unreadable collection' do
+      params = {
+        fields: { 'Tree' => 'id,name,island' },
+        header: 'id,name,island',
+      }
+      get '/forest/Tree.csv', params: params, headers: headers
+
+      expect(response.status).to eq(403)
+      body = JSON.parse(response.body)
+      expect(body['errors'][0]['detail']).to eq "You are not allowed to read 'island' from the 'Island' collection."
+      expect(body['errors'][0]['data']).to eq('fields' => ['island'])
+    end
   end
 end
 
@@ -400,6 +414,15 @@ describe 'Requesting Island resources', :type => :request  do
       'forest.collections',
       {
         'Island' => {
+          'browse'  => [1],
+          'read'    => [1],
+          'edit'    => [1],
+          'add'     => [1],
+          'delete'  => [1],
+          'export'  => [1],
+          'actions' => {}
+        },
+        'Location' => {
           'browse'  => [1],
           'read'    => [1],
           'edit'    => [1],

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -301,6 +301,10 @@ describe 'Requesting Tree resources', :type => :request  do
       get '/forest/Tree.csv', params: params, headers: headers
 
       expect(response.status).to eq(403)
+      # Not a CSV download of the JSON error: respond_to already set these for the matched
+      # format.csv before the rescue ran, so the error render must override them explicitly.
+      expect(response.headers['Content-Type']).to include('application/json')
+      expect(response.headers['Content-Disposition']).to be_nil
       body = JSON.parse(response.body)
       expect(body['errors'][0]['detail']).to eq "You are not allowed to read 'island' from the 'Island' collection."
       expect(body['errors'][0]['data']).to eq('fields' => ['island'])

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -293,21 +293,21 @@ describe 'Requesting Tree resources', :type => :request  do
       expect(csv_lines[1]).to eq('1,Lemon Tree')
     end
 
-    it 'refuses with a 403 instead of leaking unredacted data for a field of an unreadable collection' do
+    # Unlike index/show/update, an explicitly named but unreadable column drops silently instead
+    # of refusing the whole file — matching agent-nodejs's own CSV route (same redactProjection,
+    # same named-vs-not distinction it already applies to its JSON list, not a CSV-specific rule).
+    it 'drops an unreadable column silently instead of refusing the whole export' do
       params = {
         fields: { 'Tree' => 'id,name,island' },
         header: 'id,name,island',
       }
       get '/forest/Tree.csv', params: params, headers: headers
 
-      expect(response.status).to eq(403)
-      # Not a CSV download of the JSON error: respond_to already set these for the matched
-      # format.csv before the rescue ran, so the error render must override them explicitly.
-      expect(response.headers['Content-Type']).to include('application/json')
-      expect(response.headers['Content-Disposition']).to be_nil
-      body = JSON.parse(response.body)
-      expect(body['errors'][0]['detail']).to eq "You are not allowed to read 'island' from the 'Island' collection."
-      expect(body['errors'][0]['data']).to eq('fields' => ['island'])
+      expect(response.status).to eq(200)
+      expect(response.headers['Content-Type']).to include('text/csv')
+      csv_lines = response.body.split("\n")
+      expect(csv_lines.first).to eq('id,name')
+      expect(csv_lines[1]).to eq('1,Lemon Tree')
     end
   end
 end

--- a/spec/services/forest_liana/ability/redact_fields_spec.rb
+++ b/spec/services/forest_liana/ability/redact_fields_spec.rb
@@ -108,6 +108,24 @@ module ForestLiana
           end
         end
 
+        # 'name' lives in the 'User' entry, not root_model's own 'Tree' entry — the message
+        # prefixes it with 'User' so it doesn't read as a bare field of Tree, while data[:fields]
+        # (consumed by the caller to identify which fields it named) keeps the bare 'name'.
+        it 'prefixes a denied field with the relation it was reached through, unlike a root field' do
+          write_permissions('Tree' => true, 'Island' => false, 'User' => false)
+
+          expect do
+            dummy_class.redact_fields(
+              user, Tree, { 'Tree' => 'name,island', 'User' => 'name' }, named_collections: %w[Tree User]
+            )
+          end.to raise_error(
+            ForestLiana::Ability::Exceptions::UnauthorizedFieldsError,
+            "You are not allowed to read 'island' from the 'Island' collection, 'User:name' from the 'User' collection."
+          ) do |error|
+            expect(error.data[:fields]).to match_array(%w[island name])
+          end
+        end
+
         it 'drops a denied field silently when the caller never named it' do
           write_permissions('Tree' => true, 'Island' => false)
 

--- a/spec/services/forest_liana/ability/redact_fields_spec.rb
+++ b/spec/services/forest_liana/ability/redact_fields_spec.rb
@@ -133,6 +133,23 @@ module ForestLiana
             .to eq('Tree' => 'name')
         end
 
+        # Repeats "from the 'Island' collection" per field rather than grouping them, matching
+        # agent-nodejs's own redactProjection for this same case (parity, not a v1 quirk).
+        it 'repeats the "from" clause per field even when two fields reach the same collection' do
+          write_permissions('Tree' => true, 'Island' => false)
+
+          expect do
+            dummy_class.redact_fields(
+              user, Tree, { 'Tree' => 'island', 'Island' => 'name' }, named_collections: %w[Tree Island]
+            )
+          end.to raise_error(
+            ForestLiana::Ability::Exceptions::UnauthorizedFieldsError,
+            "You are not allowed to read 'island' from the 'Island' collection, 'Island:name' from the 'Island' collection."
+          ) do |error|
+            expect(error.data[:fields]).to match_array(%w[island name])
+          end
+        end
+
         # Pins the branch itself, not just each outcome in isolation: a later refactor collapsing
         # "named" and "unnamed" into one path would still pass the two examples above individually.
         it 'treats the very same denied field differently depending on whether it was named' do


### PR DESCRIPTION
## Stack

Base = `feature/prd-1083-v1-refuse-a-requested-field-the-caller-cannot-read-and` (#795).

## Context

`render_csv` (used by both the root CSV export and a relation's CSV export) never called `redact_fields`, so a role without read on a related collection could still export it via CSV even after PRD-1083 closed this exact gap for index/show/update. Every field named in a CSV export is caller-named by construction (`params[:fields][collection]` is required), so an unreadable one always refuses (403) rather than being silently dropped — there's no "default expansion" case to handle here.

## Verification

- 564 examples, 0 failures. Mutation-check done (revert → the new tests go red exactly where expected, 200 instead of 403).
- End-to-end tested live on `demo-rails8` with the gem pointed at this branch: a role with Product read denied gets `Product` silently hidden as `Restricted` on an ordinary list, and a 403 `"You are not allowed to read 'product' from the 'Product' collection."` on a CSV export naming that field explicitly.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CSV export to redact unreadable caller-named fields instead of erroring
> - `ForestLiana::ApplicationController#render_csv` now runs the requested field map through field authorization with no named collections, so denied columns are removed from the header and serialized rows while the export continues with the remaining fields.
> - `ForestLiana::ResourcesController#index` and `ForestLiana::AssociationsController#index` rescue the unauthorized-fields error during CSV negotiation, render a JSON error, and drop any `Content-Disposition` header set earlier.
> - `ForestLiana::Ability::Permission#redact_fields` records a display path for denied fields: root-collection fields keep their bare name, while fields requested through a related entry are collection-qualified. `ForestLiana::Ability::Exceptions::UnauthorizedFieldsError#initialize` uses this display path in the message while keeping the original bare path in structured data.
> - Behavioral Change: CSV exports that previously failed with an authorization error on an unreadable requested field now succeed and omit that field. Error responses for unauthorized fields during CSV negotiation now return JSON without attachment headers.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 78d274d. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->