### PR TITLE
feat(collection): let a smart field declare the columns it needs, and go lazy where every consumer has

### DIFF
--- a/app/models/forest_liana/model/collection.rb
+++ b/app/models/forest_liana/model/collection.rb
@@ -70,4 +70,32 @@ class ForestLiana::Model::Collection
       .select { |field| field[:'is_virtual'] && field[:type] == 'String' }
       .map { |field| field[:field].to_s }
   end
+
+  # is_virtual alone also matches a smart relation (has_many/belongs_to, whose reference/
+  # integration is set) — dependencies only ever govern what a computed getter's own `select`
+  # needs, so those are excluded here.
+  def computed_smart_fields
+    fields.select { |field| field[:is_virtual] && field[:reference].nil? && field[:integration].nil? }
+  end
+
+  def smart_field_dependencies_declared?
+    computed_smart_fields.all? { |field| field.key?(:dependencies) }
+  end
+
+  def smart_fields_projectable?(field_names)
+    return false unless smart_field_dependencies_declared?
+
+    requested_names = field_names.map(&:to_s)
+    computed_smart_fields
+      .select { |field| requested_names.include?(field[:field].to_s) }
+      .all? { |field| field.key?(:dependencies) }
+  end
+
+  def smart_field_dependency_columns(field_names)
+    requested_names = field_names.map(&:to_s)
+    computed_smart_fields
+      .select { |field| requested_names.include?(field[:field].to_s) }
+      .flat_map { |field| ForestLiana::SmartFieldDependencies.for(field).columns }
+      .uniq
+  end
 end

--- a/app/models/forest_liana/model/collection.rb
+++ b/app/models/forest_liana/model/collection.rb
@@ -82,13 +82,11 @@ class ForestLiana::Model::Collection
     computed_smart_fields.all? { |field| field.key?(:dependencies) }
   end
 
-  def smart_fields_projectable?(field_names)
-    return false unless smart_field_dependencies_declared?
-
-    requested_names = field_names.map(&:to_s)
-    computed_smart_fields
-      .select { |field| requested_names.include?(field[:field].to_s) }
-      .all? { |field| field.key?(:dependencies) }
+  # All-or-nothing, deliberately: an undeclared computed smart field poisons projection for the
+  # whole collection even when the request never names it (smart_field_dependencies_declared?
+  # already checks every one of them) — there is no per-request subset to narrow to here.
+  def smart_fields_projectable?
+    smart_field_dependencies_declared?
   end
 
   def smart_field_dependency_columns(field_names)
@@ -96,6 +94,14 @@ class ForestLiana::Model::Collection
     computed_smart_fields
       .select { |field| requested_names.include?(field[:field].to_s) }
       .flat_map { |field| ForestLiana::SmartFieldDependencies.for(field).columns }
+      .uniq
+  end
+
+  def smart_field_dependency_relation_paths(field_names)
+    requested_names = field_names.map(&:to_s)
+    computed_smart_fields
+      .select { |field| requested_names.include?(field[:field].to_s) }
+      .flat_map { |field| ForestLiana::SmartFieldDependencies.for(field).relation_paths }
       .uniq
   end
 end

--- a/app/serializers/forest_liana/missing_attribute_valve.rb
+++ b/app/serializers/forest_liana/missing_attribute_valve.rb
@@ -10,25 +10,31 @@ module ForestLiana
       super
     rescue ActiveModel::MissingAttributeError => exception
       column = missing_column_from(exception)
-      raise unless reloadable?(object, column)
+      return degrade(attribute_name, exception) unless reloadable?(object, column)
 
-      reload_keeping_associations(object)
-
+      # #reload itself can raise (the row was deleted between the list query and serialization,
+      # a statement timeout, ...) — kept inside this same rescue so that degrades exactly like a
+      # second MissingAttributeError would, instead of escaping this valve entirely.
       begin
+        reload_keeping_associations(object)
         result = super
         FOREST_LOGGER.warn "Field \"#{attribute_name}\" of the \"#{type}\" collection read the " \
           "\"#{column}\" column without declaring it in dependencies: — reloaded the record to " \
           'serve it, at the cost of an extra query. Add it to the field\'s dependencies: to avoid this.'
         result
-      rescue ActiveModel::MissingAttributeError => second_exception
-        FOREST_REPORTER.report second_exception
-        FOREST_LOGGER.error "Cannot retrieve the \"#{attribute_name}\" value of the \"#{type}\" " \
-          "collection because of an internal error in the getter implementation: #{second_exception.message}"
-        nil
+      rescue ActiveModel::MissingAttributeError, ActiveRecord::ActiveRecordError => second_exception
+        degrade(attribute_name, second_exception)
       end
     end
 
     private
+
+    def degrade(attribute_name, exception)
+      FOREST_REPORTER.report exception
+      FOREST_LOGGER.error "Cannot retrieve the \"#{attribute_name}\" value of the \"#{type}\" " \
+        "collection because of an internal error in the getter implementation: #{exception.message}"
+      nil
+    end
 
     # A missing attribute already loaded on this exact record (as opposed to a relation's own
     # record, read through it) can never be fixed by reloading this record — degrade immediately

--- a/app/serializers/forest_liana/missing_attribute_valve.rb
+++ b/app/serializers/forest_liana/missing_attribute_valve.rb
@@ -1,0 +1,64 @@
+module ForestLiana
+  # Included into the serializer classes SerializerFactory#serializer_for generates (after
+  # ForestAdmin::JSONAPI::Serializer, which places it above that module in the MRO — `super` below
+  # still reaches the gem's own evaluate_attr_or_block). A smart field's dependencies: can be
+  # incomplete without ever being invalid (a genuine mistake, a getter that reads a column no one
+  # thought to declare) — this is the safety valve for that: one retry, never a 500 or a silently
+  # wrong value.
+  module MissingAttributeValve
+    def evaluate_attr_or_block(attribute_name, attr_or_block)
+      super
+    rescue ActiveModel::MissingAttributeError => exception
+      column = missing_column_from(exception)
+      raise unless reloadable?(object, column)
+
+      reload_keeping_associations(object)
+
+      begin
+        result = super
+        FOREST_LOGGER.warn "Field \"#{attribute_name}\" of the \"#{type}\" collection read the " \
+          "\"#{column}\" column without declaring it in dependencies: — reloaded the record to " \
+          'serve it, at the cost of an extra query. Add it to the field\'s dependencies: to avoid this.'
+        result
+      rescue ActiveModel::MissingAttributeError => second_exception
+        FOREST_REPORTER.report second_exception
+        FOREST_LOGGER.error "Cannot retrieve the \"#{attribute_name}\" value of the \"#{type}\" " \
+          "collection because of an internal error in the getter implementation: #{second_exception.message}"
+        nil
+      end
+    end
+
+    private
+
+    # A missing attribute already loaded on this exact record (as opposed to a relation's own
+    # record, read through it) can never be fixed by reloading this record — degrade immediately
+    # rather than pay for a query that will only fail the same way again.
+    def reloadable?(record, column)
+      column.present? && record.is_a?(ActiveRecord::Base) && record.persisted? &&
+        record.class.column_names.include?(column) && !record.has_attribute?(column)
+    end
+
+    # Rails 6.1 mutates @association_cache in place on #reload; Rails 8.1 replaces it with an
+    # empty one — either way, an already-eager-loaded relation would otherwise re-query at
+    # serialization time. Captured and restored around the reload so neither version's behavior
+    # costs this valve an extra join.
+    def reload_keeping_associations(record)
+      loaded_targets = record.class.reflect_on_all_associations.each_with_object({}) do |reflection, targets|
+        association = record.association(reflection.name)
+        targets[reflection.name] = association.target if association.loaded?
+      end
+
+      record.reload
+
+      loaded_targets.each { |name, target| record.association(name).target = target }
+    end
+
+    # NameError#name is nil for this exception on every Rails version this gem supports — the
+    # column has to come from the message instead. Format changed between Rails versions:
+    # "missing attribute: name" (<= 7.0) vs "missing attribute 'name' for Owner" (>= 7.1).
+    def missing_column_from(exception)
+      match = exception.message.match(/missing attribute:?\s+'?([a-zA-Z_][a-zA-Z0-9_]*)'?/)
+      match && match[1]
+    end
+  end
+end

--- a/app/serializers/forest_liana/serializer_factory.rb
+++ b/app/serializers/forest_liana/serializer_factory.rb
@@ -121,6 +121,7 @@ module ForestLiana
     def serializer_for(active_record_class)
       serializer = Class.new {
         include ForestAdmin::JSONAPI::Serializer
+        include ForestLiana::MissingAttributeValve
 
         def id
           pk = object.class.primary_key

--- a/app/services/forest_liana/base_getter.rb
+++ b/app/services/forest_liana/base_getter.rb
@@ -54,21 +54,23 @@ module ForestLiana
         preloader = ActiveRecord::Associations::Preloader.new(records: records, associations: associations)
         preloader.loaders
         preloader.branches.each do |branch|
-          branch.loaders.each { |loader| assign_preloaded_targets(records, branch.association, loader.records_by_owner) }
+          branch.loaders.each { |loader| assign_preloaded_targets(branch.association, loader.records_by_owner) }
         end
       else
         associations.each do |association|
           ActiveRecord::Associations::Preloader.new.preload(records, association).each do |loader|
-            assign_preloaded_targets(records, association, loader.records_by_owner)
+            assign_preloaded_targets(association, loader.records_by_owner)
           end
         end
       end
     end
 
-    def assign_preloaded_targets(records, association_name, records_by_owner)
+    # records_by_owner's keys are the exact objects the Preloader was given, not copies — no need
+    # to re-find them by id, which would also mis-assign on a nil or duplicate id (composite
+    # primary keys are supported elsewhere in this gem).
+    def assign_preloaded_targets(association_name, records_by_owner)
       records_by_owner.each do |record, target|
-        record_index = records.find_index { |r| r.id == record.id }
-        records[record_index].define_singleton_method(association_name) { target.first }
+        record.define_singleton_method(association_name) { target.first }
       end
     end
 
@@ -116,6 +118,13 @@ module ForestLiana
       #         JoinDependency override, which runs when the query really eager loads; it would
       #         otherwise reach the SQL as a column name.
       records.eager_loading? ? records.select(*select) : records.select(*select.drop(1))
+    end
+
+    # count may never have run #perform on this instance (it builds its own getter and calls
+    # #count directly) — falls back to @records, the filtered-but-unprojected query prepare_query
+    # already built, so a narrowed multi-column select is never handed to COUNT.
+    def unprojected_records
+      @unprojected_records || @records
     end
 
     # NOTICE: joined_relations names the relations this query joins, and so the only ones whose
@@ -176,6 +185,19 @@ module ForestLiana
         select_foreign_keys(select, projected_resource, association, joined?(association, joined_relations))
 
         active_storage_associations_processed.add(association.name)
+      end
+
+      # preload_polymorphic_associations reads a polymorphic association's own foreign_type
+      # internally to resolve its target class, whether or not that association was itself
+      # requested as a projected field — @includes already carries every one it might preload
+      # (searchExtended widens it beyond @field_names_requested for exactly this reason), so this
+      # runs over @includes rather than only the requested subset the loop below covers.
+      @includes.each do |path|
+        association = path.is_a?(Symbol) ? projected_resource.reflect_on_association(path) : get_one_association(path)
+        next unless association && SchemaUtils.polymorphic?(association)
+
+        select << "#{projected_resource.table_name}.#{association.foreign_type}"
+        select_foreign_keys(select, projected_resource, association, joined?(association, joined_relations))
       end
 
       @field_names_requested.each do |path|
@@ -263,11 +285,23 @@ module ForestLiana
       end
 
       # A requested Smart Field's own declared columns — never its relation paths, which name a
-      # relation to preload rather than a column this select could name (PRD-1089's concern, not
-      # this one's). project? already refused this whole projection unless every computed Smart
-      # Field on the collection declares, so a requested-but-undeclared one can't reach here.
+      # relation to preload rather than a column this select could name (unimplemented today).
+      # project? already refused this whole projection unless every computed Smart Field on the
+      # collection declares, so a requested-but-undeclared one can't reach here.
       @collection.smart_field_dependency_columns(@field_names_requested).each do |column_name|
         select << "#{projected_resource.table_name}.#{column_name}" if column?(projected_resource, column_name)
+      end
+
+      # A relation path's own preload is unimplemented today — but a belongs_to's
+      # foreign key still has to be selected here, or reading the association at all (before ever
+      # reaching the column beyond it) already raises on this record's own missing FK. get_one_
+      # association answers nil for a has_many first hop (e.g. trees:name) — select_foreign_keys
+      # only ever acts on belongs_to/has_one anyway, so that case is a no-op here, correctly.
+      @collection.smart_field_dependency_relation_paths(@field_names_requested).each do |relation_path|
+        association = get_one_association(relation_path.relations.first)
+        next unless association
+
+        select_foreign_keys(select, projected_resource, association, joined?(association, joined_relations))
       end
 
       select.uniq

--- a/app/services/forest_liana/base_getter.rb
+++ b/app/services/forest_liana/base_getter.rb
@@ -100,6 +100,12 @@ module ForestLiana
         select << "#{projected_resource.table_name}.#{pk}"
       end
 
+      # An STI model needs its own type column projected regardless of what's requested: without
+      # it, .becomes(subclass) later has nothing to key off, and every row loads as the base class.
+      if column?(projected_resource, projected_resource.inheritance_column)
+        select << "#{projected_resource.table_name}.#{projected_resource.inheritance_column}"
+      end
+
       # Include columns used in default ordering for batch cursor compatibility
       if projected_resource.respond_to?(:default_scoped) && projected_resource.default_scoped.order_values.any?
         projected_resource.default_scoped.order_values.each do |order_value|

--- a/app/services/forest_liana/base_getter.rb
+++ b/app/services/forest_liana/base_getter.rb
@@ -231,6 +231,14 @@ module ForestLiana
         end
       end
 
+      # A requested Smart Field's own declared columns — never its relation paths, which name a
+      # relation to preload rather than a column this select could name (PRD-1089's concern, not
+      # this one's). project? already refused this whole projection unless every computed Smart
+      # Field on the collection declares, so a requested-but-undeclared one can't reach here.
+      @collection.smart_field_dependency_columns(@field_names_requested).each do |column_name|
+        select << "#{projected_resource.table_name}.#{column_name}" if column?(projected_resource, column_name)
+      end
+
       select.uniq
     end
 

--- a/app/services/forest_liana/base_getter.rb
+++ b/app/services/forest_liana/base_getter.rb
@@ -41,6 +41,37 @@ module ForestLiana
       result
     end
 
+    # Rails 7 introduced records:/associations: keyword preloading with a branches/loaders
+    # structure this method walks to define a singleton accessor per polymorphic target; 6.1's
+    # Preloader#preload takes the same records/associations positionally and returns the loaders
+    # directly (one per target class among the polymorphic records), without that branch grouping
+    # - preloaded one association at a time here so its name is already known, not read back off
+    # a branch this version's Preloader doesn't expose.
+    def preload_polymorphic_associations(records, associations)
+      return if associations.empty? || records.empty?
+
+      if Rails::VERSION::MAJOR >= 7
+        preloader = ActiveRecord::Associations::Preloader.new(records: records, associations: associations)
+        preloader.loaders
+        preloader.branches.each do |branch|
+          branch.loaders.each { |loader| assign_preloaded_targets(records, branch.association, loader.records_by_owner) }
+        end
+      else
+        associations.each do |association|
+          ActiveRecord::Associations::Preloader.new.preload(records, association).each do |loader|
+            assign_preloaded_targets(records, association, loader.records_by_owner)
+          end
+        end
+      end
+    end
+
+    def assign_preloaded_targets(records, association_name, records_by_owner)
+      records_by_owner.each do |record, target|
+        record_index = records.find_index { |r| r.id == record.id }
+        records[record_index].define_singleton_method(association_name) { target.first }
+      end
+    end
+
     def analyze_associations(resource)
       polymorphic = []
       preload_loads = @includes.uniq.select do |name|

--- a/app/services/forest_liana/has_many_getter.rb
+++ b/app/services/forest_liana/has_many_getter.rb
@@ -75,7 +75,16 @@ module ForestLiana
     end
 
     def records
-      @records.limit(limit).offset(offset)
+      records = @records.limit(limit).offset(offset)
+      polymorphic_associations, = analyze_associations(model_association)
+
+      # Left a Relation (not resolved yet) when there is nothing to preload - some callers still
+      # want #to_sql off this, and paid for nothing before this fix.
+      return records if polymorphic_associations.empty?
+
+      records = records.to_a
+      preload_polymorphic_associations(records, polymorphic_associations)
+      records
     end
 
     def includes_for_serialization

--- a/app/services/forest_liana/has_many_getter.rb
+++ b/app/services/forest_liana/has_many_getter.rb
@@ -30,6 +30,11 @@ module ForestLiana
     #         display-only ones are preloaded on purpose, and come back whole.
     def perform
       assert_sort_readable!
+      # Captured even on the early return: a `.select` naming more than one column makes Rails
+      # emit `COUNT(col1, col2)`, invalid SQL, if #count ever ran off @records post-projection
+      # instead — count builds its own getter today and never calls perform, so this is a guard
+      # against that changing, not a live gap.
+      @unprojected_records = @records
       return @records unless project?
 
       polymorphic_associations, preload_loads = analyze_associations(model_association)
@@ -40,6 +45,7 @@ module ForestLiana
 
     def count
       association_class = model_association
+      records = unprojected_records
 
       if association_class.primary_key.is_a?(Array)
         adapter_name = association_class.connection.adapter_name.downcase
@@ -53,14 +59,14 @@ module ForestLiana
             "#{association_class.table_name}.#{pk}"
           end.join(" || '|' || ")
 
-          @records_count = @records.distinct.count(Arel.sql(pk_concat))
+          @records_count = records.distinct.count(Arel.sql(pk_concat))
         elsif adapter_name.include?('postgresql')
-          @records_count = @records.distinct.count(Arel.sql("ROW(#{pk_columns})"))
+          @records_count = records.distinct.count(Arel.sql("ROW(#{pk_columns})"))
         else
-          @records_count = @records.distinct.count(Arel.sql(pk_columns))
+          @records_count = records.distinct.count(Arel.sql(pk_columns))
         end
       else
-        @records_count = @records.count
+        @records_count = records.count
       end
     end
 
@@ -125,6 +131,12 @@ module ForestLiana
 
     def projected_resource
       model_association
+    end
+
+    # perform may never have run on this instance (count builds its own getter) — falls back to
+    # @records, the filtered-but-unprojected query prepare_query already built.
+    def unprojected_records
+      @unprojected_records || @records
     end
 
     def model_association

--- a/app/services/forest_liana/has_many_getter.rb
+++ b/app/services/forest_liana/has_many_getter.rb
@@ -121,12 +121,14 @@ module ForestLiana
       Array(fields&.split(',')).map(&:to_sym)
     end
 
-    # NOTICE: A projection naming a Smart Field is dropped: computing one may read any column of
-    #         the record, as ResourcesGetter#perform already assumes for the list.
+    # NOTICE: A projection naming an undeclared Smart Field is dropped: computing one may read
+    #         any column of the record, as ResourcesGetter#perform already assumes for the list.
+    #         A Smart Field whose every dependency is declared, on a collection where every one of
+    #         them is, is safe to narrow instead — compute_select_fields adds the columns it needs.
     def project?
       return false if @field_names_requested.empty?
 
-      @field_names_requested.none? { |field| ForestLiana::SchemaHelper.is_smart_field?(model_association, field.to_s) }
+      @collection.smart_fields_projectable?(@field_names_requested)
     end
 
     def projected_resource

--- a/app/services/forest_liana/has_many_getter.rb
+++ b/app/services/forest_liana/has_many_getter.rb
@@ -31,9 +31,7 @@ module ForestLiana
     def perform
       assert_sort_readable!
       # Captured even on the early return: a `.select` naming more than one column makes Rails
-      # emit `COUNT(col1, col2)`, invalid SQL, if #count ever ran off @records post-projection
-      # instead — count builds its own getter today and never calls perform, so this is a guard
-      # against that changing, not a live gap.
+      # emit `COUNT(col1, col2)`, invalid SQL, if #count ever ran off @records post-projection.
       @unprojected_records = @records
       return @records unless project?
 
@@ -130,24 +128,15 @@ module ForestLiana
       Array(fields&.split(',')).map(&:to_sym)
     end
 
-    # NOTICE: A projection naming an undeclared Smart Field is dropped: computing one may read
-    #         any column of the record, as ResourcesGetter#perform already assumes for the list.
-    #         A Smart Field whose every dependency is declared, on a collection where every one of
-    #         them is, is safe to narrow instead — compute_select_fields adds the columns it needs.
+    # See Model::Collection#smart_fields_projectable? for why this is all-or-nothing per collection.
     def project?
       return false if @field_names_requested.empty?
 
-      @collection.smart_fields_projectable?(@field_names_requested)
+      @collection.smart_fields_projectable?
     end
 
     def projected_resource
       model_association
-    end
-
-    # perform may never have run on this instance (count builds its own getter) — falls back to
-    # @records, the filtered-but-unprojected query prepare_query already built.
-    def unprojected_records
-      @unprojected_records || @records
     end
 
     def model_association

--- a/app/services/forest_liana/resource_getter.rb
+++ b/app/services/forest_liana/resource_getter.rb
@@ -59,14 +59,12 @@ module ForestLiana
       end
     end
 
-    # NOTICE: A projection naming a Smart Field is dropped: computing one may read any column of
-    #         the record, as ResourcesGetter#perform already assumes for the list.
+    # NOTICE: A projection naming an undeclared Smart Field is dropped: computing one may read
+    #         any column of the record, as ResourcesGetter#perform already assumes for the list.
+    #         A Smart Field whose every dependency is declared, on a collection where every one of
+    #         them is, is safe to narrow instead — compute_select_fields adds the columns it needs.
     def project?
-      projection? && !smart_field_requested?
-    end
-
-    def smart_field_requested?
-      @field_names_requested.any? { |field| ForestLiana::SchemaHelper.is_smart_field?(@resource, field.to_s) }
+      projection? && @collection.smart_fields_projectable?(@field_names_requested)
     end
   end
 end

--- a/app/services/forest_liana/resource_getter.rb
+++ b/app/services/forest_liana/resource_getter.rb
@@ -59,12 +59,9 @@ module ForestLiana
       end
     end
 
-    # NOTICE: A projection naming an undeclared Smart Field is dropped: computing one may read
-    #         any column of the record, as ResourcesGetter#perform already assumes for the list.
-    #         A Smart Field whose every dependency is declared, on a collection where every one of
-    #         them is, is safe to narrow instead — compute_select_fields adds the columns it needs.
+    # See Model::Collection#smart_fields_projectable? for why this is all-or-nothing per collection.
     def project?
-      projection? && @collection.smart_fields_projectable?(@field_names_requested)
+      projection? && @collection.smart_fields_projectable?
     end
   end
 end

--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -71,21 +71,7 @@ module ForestLiana
       records = @records.offset(offset).limit(limit).to_a
       polymorphic_association, preload_loads = analyze_associations(@resource)
 
-      if polymorphic_association.any? && Rails::VERSION::MAJOR >= 7
-        preloader = ActiveRecord::Associations::Preloader.new(records: records, associations: polymorphic_association)
-        preloader.loaders
-        preloader.branches.each do |branch|
-          branch.loaders.each do |loader|
-            records_by_owner = loader.records_by_owner
-            records_by_owner.each do |record, association|
-              record_index =  records.find_index { |r| r.id == record.id }
-              records[record_index].define_singleton_method(branch.association) do
-                association.first
-              end
-            end
-          end
-        end
-      end
+      preload_polymorphic_associations(records, polymorphic_association)
 
       records
     end

--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -41,19 +41,22 @@ module ForestLiana
       # makes Rails emit `COUNT(col1, col2)`, invalid SQL, if `.count` ever ran off it instead.
       @unprojected_records = optimize_record_loading(@resource, @records, false)
 
-      has_smart_fields = Array(@params.dig(:fields, @collection_name)&.split(',')).any? do |field|
-        ForestLiana::SchemaHelper.is_smart_field?(@resource, field)
-      end
-
-      @records = if has_smart_fields
-        @unprojected_records
-      else
+      @records = if project?
         polymorphic_association, preload_loads = analyze_associations(@resource)
         includes = @includes.uniq - polymorphic_association - preload_loads - @optional_includes
         apply_projection(@unprojected_records, includes)
+      else
+        @unprojected_records
       end
 
       @records
+    end
+
+    # NOTICE: Without a fields[] param at all, serialization is unoptimized (every field of every
+    #         relation the request touches) — projecting would starve fields the caller never
+    #         named but still expects back.
+    def projection?
+      !@params.dig(:fields, @collection_name).nil?
     end
 
     def count
@@ -142,6 +145,14 @@ module ForestLiana
     end
 
     private
+
+    # NOTICE: A projection naming an undeclared Smart Field is dropped: computing one may read
+    #         any column of the record. A Smart Field whose every dependency is declared, on a
+    #         collection where every one of them is, is safe to narrow instead —
+    #         compute_select_fields adds the columns it needs.
+    def project?
+      projection? && @collection.smart_fields_projectable?(@fields_to_serialize)
+    end
 
     def get_fields_to_serialize
       @params.dig(:fields, @collection_name)&.split(',')&.map(&:to_sym) || []

--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -132,12 +132,9 @@ module ForestLiana
 
     private
 
-    # NOTICE: A projection naming an undeclared Smart Field is dropped: computing one may read
-    #         any column of the record. A Smart Field whose every dependency is declared, on a
-    #         collection where every one of them is, is safe to narrow instead —
-    #         compute_select_fields adds the columns it needs.
+    # See Model::Collection#smart_fields_projectable? for why this is all-or-nothing per collection.
     def project?
-      projection? && @collection.smart_fields_projectable?(@fields_to_serialize)
+      projection? && @collection.smart_fields_projectable?
     end
 
     def get_fields_to_serialize
@@ -202,13 +199,6 @@ module ForestLiana
 
     def optimized_count
       optimize_record_loading(@resource, unprojected_records).count
-    end
-
-    # perform may never have run on this instance (the count HTTP action builds its own getter
-    # and calls #count directly) — falls back to @records, the filtered-but-unselected query
-    # prepare_query already built.
-    def unprojected_records
-      @unprojected_records || @records
     end
 
     def apply_segment(records)

--- a/app/services/forest_liana/resources_getter.rb
+++ b/app/services/forest_liana/resources_getter.rb
@@ -36,24 +36,28 @@ module ForestLiana
 
     def perform
       assert_sort_readable!
-      polymorphic_association, preload_loads = analyze_associations(@resource)
-      includes = @includes.uniq - polymorphic_association - preload_loads - @optional_includes
+      # Captured before any select narrows @records: count/optimized_count must build its COUNT
+      # off this, never off @records past this point — a `.select` naming more than one column
+      # makes Rails emit `COUNT(col1, col2)`, invalid SQL, if `.count` ever ran off it instead.
+      @unprojected_records = optimize_record_loading(@resource, @records, false)
+
       has_smart_fields = Array(@params.dig(:fields, @collection_name)&.split(',')).any? do |field|
         ForestLiana::SchemaHelper.is_smart_field?(@resource, field)
       end
 
-      if includes.empty? || has_smart_fields
-        @records = optimize_record_loading(@resource, @records, false)
+      @records = if has_smart_fields
+        @unprojected_records
       else
-        select = compute_select_fields
-        @records = optimize_record_loading(@resource, @records, false).references(includes).select(*select)
+        polymorphic_association, preload_loads = analyze_associations(@resource)
+        includes = @includes.uniq - polymorphic_association - preload_loads - @optional_includes
+        apply_projection(@unprojected_records, includes)
       end
 
       @records
     end
 
     def count
-      @records_count = @count_needs_includes ? optimized_count : @records.count
+      @records_count = @count_needs_includes ? optimized_count : unprojected_records.count
     end
 
     def query_for_batch
@@ -200,7 +204,14 @@ module ForestLiana
     end
 
     def optimized_count
-      optimize_record_loading(@resource, @records).count
+      optimize_record_loading(@resource, unprojected_records).count
+    end
+
+    # perform may never have run on this instance (the count HTTP action builds its own getter
+    # and calls #count directly) — falls back to @records, the filtered-but-unselected query
+    # prepare_query already built.
+    def unprojected_records
+      @unprojected_records || @records
     end
 
     def apply_segment(records)

--- a/app/services/forest_liana/smart_field_dependencies.rb
+++ b/app/services/forest_liana/smart_field_dependencies.rb
@@ -1,7 +1,7 @@
 module ForestLiana
   # Parses the `dependencies:` a smart field declares (Forest field paths: a bare column name to
-  # select, or an `a:b:c` relation path to preload — this class only splits the two apart; PRD-1089
-  # adds the preload side, reusing #relation_paths as-is).
+  # select, or an `a:b:c` relation path to preload — this class only splits the two apart; the
+  # preload side itself is unimplemented today, #relation_paths is ready for it as-is).
   class SmartFieldDependencies
     RelationPath = Struct.new(:relations, :column)
 
@@ -42,6 +42,11 @@ module ForestLiana
       end
 
       target.present? && target.column_names.include?(column_name)
+    rescue NameError, ActiveRecord::ActiveRecordError
+      # reflection.klass on a bad class_name:, or column_names against a table that doesn't exist
+      # yet in this environment — same "degrade, don't crash the boot" treatment validate! already
+      # gives any other invalid entry, not a new failure mode of its own.
+      false
     end
 
     def initialize(entries)

--- a/app/services/forest_liana/smart_field_dependencies.rb
+++ b/app/services/forest_liana/smart_field_dependencies.rb
@@ -1,0 +1,62 @@
+module ForestLiana
+  # Parses the `dependencies:` a smart field declares (Forest field paths: a bare column name to
+  # select, or an `a:b:c` relation path to preload — this class only splits the two apart; PRD-1089
+  # adds the preload side, reusing #relation_paths as-is).
+  class SmartFieldDependencies
+    RelationPath = Struct.new(:relations, :column)
+
+    def self.normalize(raw)
+      return nil unless raw.is_a?(String) || raw.is_a?(Symbol) || raw.is_a?(Array)
+
+      entries = raw.is_a?(Array) ? raw : [raw]
+      entries.map(&:to_s).map(&:strip).reject(&:empty?).uniq
+    end
+
+    def self.for(field)
+      new(field[:dependencies] || [])
+    end
+
+    def self.validate!(model, collection_name, field)
+      dependencies = field[:dependencies]
+      return if dependencies.nil?
+
+      invalid = dependencies.find { |entry| !valid_entry?(model, entry) }
+      return unless invalid
+
+      FOREST_LOGGER.warn "Invalid dependency '#{invalid}' declared on smart field " \
+        "'#{field[:field]}' of the '#{collection_name}' collection: it does not resolve to a " \
+        'real column, or crosses a polymorphic relation. Ignored — the field is treated as if it ' \
+        'declared no dependencies at all.'
+      field.delete(:dependencies)
+    end
+
+    def self.valid_entry?(model, entry)
+      *relation_names, column_name = entry.split(':')
+      target = relation_names.reduce(model) do |current_model, relation_name|
+        return false if current_model.nil?
+
+        reflection = current_model.reflect_on_association(relation_name.to_sym)
+        return false if reflection.nil? || reflection.polymorphic?
+
+        reflection.klass
+      end
+
+      target.present? && target.column_names.include?(column_name)
+    end
+
+    def initialize(entries)
+      @entries = entries
+    end
+
+    def columns
+      @entries.reject { |entry| entry.include?(':') }
+    end
+
+    def relation_paths
+      @entries.select { |entry| entry.include?(':') }.map do |entry|
+        *relations, column = entry.split(':')
+        RelationPath.new(relations, column)
+      end
+    end
+  end
+end

--- a/config/initializers/errors.rb
+++ b/config/initializers/errors.rb
@@ -30,17 +30,6 @@ module ForestLiana
       end
     end
 
-    # Never actually raised by SmartFieldDependencies.validate! today, which warns and degrades
-    # to undeclared instead (an invalid dependency is a developer mistake worth surfacing loudly
-    # in the logs, but not worth crashing every request on) — kept for the same shape every other
-    # Smart*InvalidFieldError in this file has, and for a caller that wants to raise explicitly.
-    class SmartFieldInvalidDependencyError < StandardError
-      def initialize(field_name=nil, collection_name=nil, dependency=nil)
-        super("Invalid dependency \"#{dependency}\" declared on field \"#{field_name}\" of the " \
-          "\"#{collection_name}\" collection.")
-      end
-    end
-
     class AuthenticationOpenIdClientException < StandardError
       attr_reader :error, :error_description, :state
 

--- a/config/initializers/errors.rb
+++ b/config/initializers/errors.rb
@@ -30,6 +30,17 @@ module ForestLiana
       end
     end
 
+    # Never actually raised by SmartFieldDependencies.validate! today, which warns and degrades
+    # to undeclared instead (an invalid dependency is a developer mistake worth surfacing loudly
+    # in the logs, but not worth crashing every request on) — kept for the same shape every other
+    # Smart*InvalidFieldError in this file has, and for a caller that wants to raise explicitly.
+    class SmartFieldInvalidDependencyError < StandardError
+      def initialize(field_name=nil, collection_name=nil, dependency=nil)
+        super("Invalid dependency \"#{dependency}\" declared on field \"#{field_name}\" of the " \
+          "\"#{collection_name}\" collection.")
+      end
+    end
+
     class AuthenticationOpenIdClientException < StandardError
       attr_reader :error, :error_description, :state
 

--- a/lib/forest_liana/bootstrapper.rb
+++ b/lib/forest_liana/bootstrapper.rb
@@ -79,6 +79,7 @@ module ForestLiana
       create_apimap
       require_lib_forest_liana
       format_and_validate_smart_actions
+      validate_smart_field_dependencies
 
       if Rails.env.development?
         @collections_sent = ForestLiana.apimap.as_json
@@ -253,6 +254,20 @@ module ForestLiana
               field[:position] = index
             end
           end
+        end
+      end
+    end
+
+    # An invalid dependency degrades to undeclared (SmartFieldDependencies.validate! deletes the
+    # key and warns) rather than crashing the boot — same warn-don't-crash pattern as smart action
+    # fields above.
+    def validate_smart_field_dependencies
+      ForestLiana.apimap.each do |collection|
+        model = SchemaUtils.find_model_from_collection_name(collection.name)
+        next if model.nil?
+
+        collection.fields.each do |field|
+          SmartFieldDependencies.validate!(model, collection.name, field)
         end
       end
     end

--- a/lib/forest_liana/collection.rb
+++ b/lib/forest_liana/collection.rb
@@ -41,8 +41,26 @@ module ForestLiana::Collection
       model.search_fields = fields
     end
 
+    # A key absent from opts stays absent (collection_spec.rb pins the exact field hash a smart
+    # field with no dependencies produces) — only a *present* dependencies: is ever touched here.
+    def normalize_dependencies!(opts, name)
+      return unless opts.key?(:dependencies)
+      return opts.delete(:dependencies) if opts[:dependencies].nil?
+
+      normalized = ForestLiana::SmartFieldDependencies.normalize(opts[:dependencies])
+      if normalized.nil?
+        FOREST_LOGGER.warn "Invalid dependencies declared on field \"#{name}\": expected a " \
+          'String, Symbol, or Array of them. Ignored — the field is treated as if it declared ' \
+          'no dependencies at all.'
+        opts.delete(:dependencies)
+      else
+        opts[:dependencies] = normalized
+      end
+    end
+
     def field(name, opts, &block)
       # TODO: Handle empty name
+      normalize_dependencies!(opts, name)
 
       if opts.key?(:isRequired)
         FOREST_LOGGER.warn "DEPRECATION WARNING: isRequired on field \"#{name}\" is deprecated. Please use is_required."
@@ -123,6 +141,8 @@ module ForestLiana::Collection
     end
 
     def has_many(name, opts, &block)
+      normalize_dependencies!(opts, name)
+
       field = opts.merge({
         field: name,
         is_virtual: true,
@@ -143,6 +163,8 @@ module ForestLiana::Collection
     end
 
     def belongs_to(name, opts, &block)
+      normalize_dependencies!(opts, name)
+
       field = opts.merge({
         field: name,
         is_virtual: true,

--- a/lib/forest_liana/collection.rb
+++ b/lib/forest_liana/collection.rb
@@ -123,6 +123,11 @@ module ForestLiana::Collection
             compute_value = lambda do |object|
               begin
                 object.instance_eval(&block)
+              rescue ActiveModel::MissingAttributeError
+                # Left to propagate: MissingAttributeValve (wrapping evaluate_attr_or_block, the
+                # caller of this lambda) is the one place that can tell a genuine mistake apart
+                # from a dependencies: declaration merely incomplete, and retry only the latter.
+                raise
               rescue => exception
                 FOREST_REPORTER.report exception
                 FOREST_LOGGER.error "Cannot retrieve the " + name.to_s + " value because of an " \

--- a/spec/dummy/lib/forest_liana/collections/address.rb
+++ b/spec/dummy/lib/forest_liana/collections/address.rb
@@ -11,7 +11,7 @@ class Forest::Address
       object.addressable_type
     end
 
-    field :address_type, type: 'String' do
+    field :address_type, type: 'String', dependencies: [] do
       'delivery'
     end
 end

--- a/spec/dummy/lib/forest_liana/collections/owner.rb
+++ b/spec/dummy/lib/forest_liana/collections/owner.rb
@@ -3,7 +3,10 @@ class Forest::Owner
 
   collection :Owner
 
-  field :tree_names, type: 'String' do
+  # trees:name is a relation path (crosses the trees association) - this ticket (PRD-1086) reads
+  # only the column half of dependencies:, so this declares Owner projectable without adding
+  # anything to its own select; PRD-1089 preloads the relation path itself.
+  field :tree_names, type: 'String', dependencies: ['trees:name'] do
     object.trees.map(&:name).join(', ')
   end
 end

--- a/spec/dummy/lib/forest_liana/collections/owner.rb
+++ b/spec/dummy/lib/forest_liana/collections/owner.rb
@@ -3,9 +3,9 @@ class Forest::Owner
 
   collection :Owner
 
-  # trees:name is a relation path (crosses the trees association) - this ticket (PRD-1086) reads
-  # only the column half of dependencies:, so this declares Owner projectable without adding
-  # anything to its own select; PRD-1089 preloads the relation path itself.
+  # trees:name is a relation path (crosses the trees association) — only the column half of
+  # dependencies: is read today, so this declares Owner projectable without adding anything to
+  # its own select; the relation path itself isn't preloaded yet.
   field :tree_names, type: 'String', dependencies: ['trees:name'] do
     object.trees.map(&:name).join(', ')
   end

--- a/spec/dummy/lib/forest_liana/collections/tree.rb
+++ b/spec/dummy/lib/forest_liana/collections/tree.rb
@@ -1,0 +1,12 @@
+class Forest::Tree
+  include ForestLiana::Collection
+
+  collection :Tree
+
+  # Deliberately incomplete: reads age too, which its own dependencies: never names — the
+  # MissingAttributeValve regression fixture for "does the reload disturb an already-loaded
+  # association" (spec/requests/missing_attribute_valve_spec.rb).
+  field :name_with_age, type: 'String', dependencies: ['name'] do
+    "#{object.name} (#{object.age})"
+  end
+end

--- a/spec/dummy/lib/forest_liana/collections/tree.rb
+++ b/spec/dummy/lib/forest_liana/collections/tree.rb
@@ -9,4 +9,17 @@ class Forest::Tree
   field :name_with_age, type: 'String', dependencies: ['name'] do
     "#{object.name} (#{object.age})"
   end
+
+  # Deliberately incomplete the other way: reads a relation's own column, which its dependencies:
+  # never names — reloading this record can never fix a missing column on a different record, the
+  # MissingAttributeValve regression fixture for "degrade immediately, don't loop or crash".
+  field :owner_name, type: 'String', dependencies: ['name'] do
+    object.owner.name
+  end
+
+  # A relation-path dependency (crosses the belongs_to owner association) — the fixture for
+  # "does declaring this select the FK it needs, without ever hitting the valve" (query_footprint_spec.rb).
+  field :owner_name_declared, type: 'String', dependencies: ['owner:name'] do
+    object.owner.name
+  end
 end

--- a/spec/dummy/lib/forest_liana/collections/user.rb
+++ b/spec/dummy/lib/forest_liana/collections/user.rb
@@ -13,7 +13,7 @@ class Forest::User
     query.or(User.where("name = '#{search}'"))
   end
 
-  field :cap_name, type: 'String', filter: filter_cap_name, search: search_cap_name do
+  field :cap_name, type: 'String', filter: filter_cap_name, search: search_cap_name, dependencies: ['name'] do
     object.name.upcase
   end
 

--- a/spec/dummy/lib/forest_liana/collections/user.rb
+++ b/spec/dummy/lib/forest_liana/collections/user.rb
@@ -17,4 +17,10 @@ class Forest::User
     object.name.upcase
   end
 
+  # Deliberately incomplete: reads title too, which its own dependencies: never names — the
+  # MissingAttributeValve regression fixture (spec/requests/missing_attribute_valve_spec.rb).
+  field :name_with_title, type: 'String', dependencies: ['name'] do
+    "#{object.name} (#{object.title})"
+  end
+
 end

--- a/spec/lib/forest_liana/collection_spec.rb
+++ b/spec/lib/forest_liana/collection_spec.rb
@@ -27,7 +27,8 @@ module ForestLiana
             field: :address_type,
             is_primary_key: false,
             is_filterable: false,
-            is_sortable: false
+            is_sortable: false,
+            dependencies: []
           }
         )
       end
@@ -46,6 +47,61 @@ module ForestLiana
         expect(field).not_to be_nil
         expect(field[:is_filterable]).to eq(false)
         expect(field[:is_sortable]).to eq(true)
+      end
+    end
+
+    describe 'normalize_dependencies!' do
+      let(:dummy_class) { Class.new { extend ForestLiana::Collection::ClassMethods } }
+
+      it 'leaves opts untouched when dependencies is absent' do
+        opts = { type: 'String' }
+
+        dummy_class.normalize_dependencies!(opts, :some_field)
+
+        expect(opts).not_to have_key(:dependencies)
+      end
+
+      it 'wraps a bare String or Symbol into an Array' do
+        opts = { dependencies: 'name' }
+        dummy_class.normalize_dependencies!(opts, :some_field)
+        expect(opts[:dependencies]).to eq(['name'])
+
+        opts = { dependencies: :name }
+        dummy_class.normalize_dependencies!(opts, :some_field)
+        expect(opts[:dependencies]).to eq(['name'])
+      end
+
+      it 'strips, dedupes and drops empty entries' do
+        opts = { dependencies: [' name ', 'name', ''] }
+
+        dummy_class.normalize_dependencies!(opts, :some_field)
+
+        expect(opts[:dependencies]).to eq(['name'])
+      end
+
+      it 'accepts an empty Array as a genuine declaration (a constant getter reads no column)' do
+        opts = { dependencies: [] }
+
+        dummy_class.normalize_dependencies!(opts, :some_field)
+
+        expect(opts[:dependencies]).to eq([])
+      end
+
+      it 'treats an explicit nil the same as an absent key' do
+        opts = { dependencies: nil }
+
+        dummy_class.normalize_dependencies!(opts, :some_field)
+
+        expect(opts).not_to have_key(:dependencies)
+      end
+
+      it 'warns and removes the key for an invalid shape, rather than crashing' do
+        opts = { dependencies: { nested: 'hash' } }
+        expect(FOREST_LOGGER).to receive(:warn)
+
+        dummy_class.normalize_dependencies!(opts, :some_field)
+
+        expect(opts).not_to have_key(:dependencies)
       end
     end
   end

--- a/spec/lib/forest_liana/collection_spec.rb
+++ b/spec/lib/forest_liana/collection_spec.rb
@@ -97,7 +97,7 @@ module ForestLiana
 
       it 'warns and removes the key for an invalid shape, rather than crashing' do
         opts = { dependencies: { nested: 'hash' } }
-        expect(FOREST_LOGGER).to receive(:warn)
+        expect(FOREST_LOGGER).to receive(:warn).with(/some_field/)
 
         dummy_class.normalize_dependencies!(opts, :some_field)
 

--- a/spec/models/forest_liana/model/collection_spec.rb
+++ b/spec/models/forest_liana/model/collection_spec.rb
@@ -54,14 +54,12 @@ module ForestLiana
           ])
         end
 
-        it 'is true for a fully-declared collection, whatever is requested' do
-          expect(declared_collection.smart_fields_projectable?(['cap_name'])).to be true
-          expect(declared_collection.smart_fields_projectable?([])).to be true
+        it 'is true for a fully-declared collection' do
+          expect(declared_collection.smart_fields_projectable?).to be true
         end
 
         it 'is false for a collection with any undeclared computed smart field, even when the request never names it' do
-          expect(mixed_collection.smart_fields_projectable?(['cap_name'])).to be false
-          expect(mixed_collection.smart_fields_projectable?([])).to be false
+          expect(mixed_collection.smart_fields_projectable?).to be false
         end
       end
 

--- a/spec/models/forest_liana/model/collection_spec.rb
+++ b/spec/models/forest_liana/model/collection_spec.rb
@@ -1,0 +1,89 @@
+module ForestLiana
+  module Model
+    describe Collection do
+      def computed_field(name, dependencies_declared:, deps: [])
+        field = { field: name, is_virtual: true, reference: nil, integration: nil }
+        field[:dependencies] = deps if dependencies_declared
+        field
+      end
+
+      def smart_relation(name)
+        { field: name, is_virtual: true, reference: 'Other.id', integration: nil }
+      end
+
+      describe '#computed_smart_fields' do
+        it 'excludes a smart relation (reference set) and an integration field' do
+          collection = described_class.new(name: 'Tree', fields: [
+            computed_field(:cap_name, dependencies_declared: true, deps: ['name']),
+            smart_relation(:owner),
+            { field: :external, is_virtual: true, reference: nil, integration: 'stripe' }
+          ])
+
+          expect(collection.computed_smart_fields.map { |f| f[:field] }).to eq([:cap_name])
+        end
+      end
+
+      describe '#smart_field_dependencies_declared?' do
+        it 'is true when every computed smart field declares, empty collection included' do
+          collection = described_class.new(name: 'Tree', fields: [
+            computed_field(:cap_name, dependencies_declared: true, deps: ['name'])
+          ])
+
+          expect(collection.smart_field_dependencies_declared?).to be true
+        end
+
+        it 'is false as soon as one computed smart field does not declare, even if unrelated to what is requested' do
+          collection = described_class.new(name: 'Tree', fields: [
+            computed_field(:cap_name, dependencies_declared: true, deps: ['name']),
+            computed_field(:other, dependencies_declared: false)
+          ])
+
+          expect(collection.smart_field_dependencies_declared?).to be false
+        end
+      end
+
+      describe '#smart_fields_projectable?' do
+        let(:declared_collection) do
+          described_class.new(name: 'Tree', fields: [computed_field(:cap_name, dependencies_declared: true, deps: ['name'])])
+        end
+
+        let(:mixed_collection) do
+          described_class.new(name: 'Tree', fields: [
+            computed_field(:cap_name, dependencies_declared: true, deps: ['name']),
+            computed_field(:other, dependencies_declared: false)
+          ])
+        end
+
+        it 'is true for a fully-declared collection, whatever is requested' do
+          expect(declared_collection.smart_fields_projectable?(['cap_name'])).to be true
+          expect(declared_collection.smart_fields_projectable?([])).to be true
+        end
+
+        it 'is false for a collection with any undeclared computed smart field, even when the request never names it' do
+          expect(mixed_collection.smart_fields_projectable?(['cap_name'])).to be false
+          expect(mixed_collection.smart_fields_projectable?([])).to be false
+        end
+      end
+
+      describe '#smart_field_dependency_columns' do
+        it 'unions the bare-column dependencies of the requested smart fields, dropping relation paths' do
+          collection = described_class.new(name: 'Tree', fields: [
+            computed_field(:cap_name, dependencies_declared: true, deps: %w[name island:name]),
+            computed_field(:other, dependencies_declared: true, deps: ['age'])
+          ])
+
+          expect(collection.smart_field_dependency_columns(['cap_name'])).to eq(['name'])
+        end
+
+        it 'ignores a smart field that was not requested' do
+          collection = described_class.new(name: 'Tree', fields: [
+            computed_field(:cap_name, dependencies_declared: true, deps: ['name']),
+            computed_field(:other, dependencies_declared: true, deps: ['age'])
+          ])
+
+          expect(collection.smart_field_dependency_columns(['cap_name'])).to eq(['name'])
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/missing_attribute_valve_spec.rb
+++ b/spec/requests/missing_attribute_valve_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+describe 'MissingAttributeValve', type: :request do
+  before do
+    allow(ForestLiana::IpWhitelist).to receive(:retrieve) { true }
+    allow(ForestLiana::IpWhitelist).to receive(:is_ip_whitelist_retrieved) { true }
+    allow(ForestLiana::IpWhitelist).to receive(:is_ip_valid) { true }
+    allow_any_instance_of(ForestLiana::Ability).to receive(:forest_authorize!) { true }
+    Rails.cache.write('forest.has_permission', false)
+    allow(ForestLiana::ScopeManager).to receive(:fetch_scopes)
+      .and_return({ 'scopes' => {}, 'team' => { 'id' => '1', 'name' => 'Operations' } })
+  end
+
+  token = JWT.encode({ id: 38, email: 'michael.kelso@that70.show', first_name: 'Michael',
+                        last_name: 'Kelso', team: 'Operations', rendering_id: 16,
+                        exp: Time.now.to_i + 2.weeks.to_i, permission_level: 'admin' },
+                      ForestLiana.auth_secret, 'HS256')
+  headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/json',
+              'Authorization' => "Bearer #{token}" }
+
+  # User#name_with_title (spec/dummy's fixture) declares dependencies: ['name'] but its getter
+  # also reads title — deliberately incomplete, the exact mistake this valve exists for.
+  describe 'a Smart Field whose declared dependencies are incomplete' do
+    let!(:user) { User.create!(name: 'Michel', title: :king) }
+
+    it 'still serves the correct value, reloading once rather than crashing or returning nil' do
+      queries = capture_queries do
+        get '/forest/User', params: { fields: { 'User' => 'id,name_with_title' }, page: { number: '1', size: '10' },
+                                       searchExtended: '0', timezone: 'Europe/Paris' }, headers: headers
+      end
+
+      expect(response.status).to eq 200
+      body = JSON.parse(response.body)
+      expect(body['data'][0]['attributes']['name_with_title']).to eq('Michel (king)')
+      expect(selects_from(queries, 'users').size).to eq(2) # the original projected select, then the reload
+    end
+
+    it 'warns once, and never reports to FOREST_REPORTER, on a successful retry' do
+      expect(FOREST_LOGGER).to receive(:warn).once.with(/name_with_title.*title/m)
+      expect(FOREST_REPORTER).not_to receive(:report)
+
+      get '/forest/User', params: { fields: { 'User' => 'id,name_with_title' }, page: { number: '1', size: '10' },
+                                     searchExtended: '0', timezone: 'Europe/Paris' }, headers: headers
+    end
+  end
+
+  # Tree#name_with_age (spec/dummy's fixture) declares dependencies: ['name'] but its getter also
+  # reads age — the same incomplete-declaration mistake, on the record whose own reload must not
+  # disturb an association already eager-loaded alongside it.
+  describe 'an association already eager-loaded when the valve reloads the record' do
+    let!(:owner) { User.create!(name: 'Michel', title: :king) }
+    let!(:tree) { Tree.create!(name: 'Oak', age: 5, owner: owner, cutter: owner) }
+
+    it 'does not re-query the joined relation, reload restores its already-loaded target' do
+      queries = capture_queries do
+        get '/forest/Tree', params: { fields: { 'Tree' => 'id,name_with_age,owner', 'owner' => 'name' },
+                                       page: { number: '1', size: '10' }, searchExtended: '0', timezone: 'Europe/Paris' }, headers: headers
+      end
+
+      expect(response.status).to eq 200
+      body = JSON.parse(response.body)
+      expect(body['data'][0]['attributes']['name_with_age']).to eq('Oak (5)')
+      # One reload of the tree row itself, once the incomplete projection misses age - the owner
+      # join from the original query must survive that reload rather than being re-queried.
+      expect(selects_from(queries, 'trees').size).to eq(2)
+      expect(selects_from(queries, 'users').size).to eq(0)
+    end
+  end
+
+  # Location#alter_coordinates (spec/dummy's fixture) reads object.name, which does not exist on
+  # Location at all - a NoMethodError, not a MissingAttributeError. Rescued by the getter's own
+  # existing rescue (lib/forest_liana/collection.rb) before it ever reaches the valve, and the
+  # valve's own rescue clause is typed to MissingAttributeError alone regardless - degrades
+  # exactly as it did before this valve existed, on both counts.
+  describe 'a getter reading a genuinely non-existent method' do
+    let!(:island) { Island.create!(name: 'Reunion') }
+    let!(:location) { Location.create!(coordinates: '1,2', island: island) }
+
+    it 'still degrades to nil without reloading, exactly as it did before this valve existed' do
+      expect(FOREST_LOGGER).not_to receive(:warn)
+      expect(FOREST_REPORTER).to receive(:report)
+
+      get "/forest/Location/#{location.id}", headers: headers.merge('Forest-Projection' => 'id,coordinates,alter_coordinates')
+
+      expect(response.status).to eq 200
+      body = JSON.parse(response.body)
+      expect(body['data']['attributes']['alter_coordinates']).to be_nil
+    end
+  end
+end

--- a/spec/requests/missing_attribute_valve_spec.rb
+++ b/spec/requests/missing_attribute_valve_spec.rb
@@ -42,6 +42,21 @@ describe 'MissingAttributeValve', type: :request do
       get '/forest/User', params: { fields: { 'User' => 'id,name_with_title' }, page: { number: '1', size: '10' },
                                      searchExtended: '0', timezone: 'Europe/Paris' }, headers: headers
     end
+
+    # The row can vanish between the list query and serialization (a concurrent delete) — #reload
+    # itself raising must degrade the same way a second MissingAttributeError would, not escape
+    # this valve entirely.
+    it 'degrades to nil rather than crash when the reload itself raises' do
+      allow_any_instance_of(User).to receive(:reload).and_raise(ActiveRecord::RecordNotFound)
+      expect(FOREST_REPORTER).to receive(:report)
+
+      get '/forest/User', params: { fields: { 'User' => 'id,name_with_title' }, page: { number: '1', size: '10' },
+                                     searchExtended: '0', timezone: 'Europe/Paris' }, headers: headers
+
+      expect(response.status).to eq 200
+      body = JSON.parse(response.body)
+      expect(body['data'][0]['attributes']['name_with_title']).to be_nil
+    end
   end
 
   # Tree#name_with_age (spec/dummy's fixture) declares dependencies: ['name'] but its getter also
@@ -64,6 +79,53 @@ describe 'MissingAttributeValve', type: :request do
       # join from the original query must survive that reload rather than being re-queried.
       expect(selects_from(queries, 'trees').size).to eq(2)
       expect(selects_from(queries, 'users').size).to eq(0)
+    end
+  end
+
+  # Tree#owner_name_declared (spec/dummy's fixture) declares dependencies: ['owner:name'], a
+  # relation-path crossing the belongs_to owner association — its own preload is out of scope
+  # here, but the foreign key it needs must still be selected, or reading the association at all
+  # (before ever reaching owner's own name) would raise on Tree's own missing owner_id.
+  describe 'a smart field whose only declared dependency is a relation path' do
+    let!(:owner) { User.create!(name: 'Michel', title: :king) }
+    let!(:tree) { Tree.create!(name: 'Oak', age: 5, owner: owner, cutter: owner) }
+
+    it "serves the value without ever hitting the valve, having selected the association's own foreign key" do
+      expect(FOREST_LOGGER).not_to receive(:warn)
+      expect(FOREST_REPORTER).not_to receive(:report)
+
+      queries = capture_queries do
+        get '/forest/Tree', params: { fields: { 'Tree' => 'id,owner_name_declared' },
+                                       page: { number: '1', size: '10' }, searchExtended: '0', timezone: 'Europe/Paris' }, headers: headers
+      end
+
+      expect(response.status).to eq 200
+      body = JSON.parse(response.body)
+      expect(body['data'][0]['attributes']['owner_name_declared']).to eq('Michel')
+      # Exactly the same footprint as an ordinary, non-preloaded belongs_to lookup: the tree's own
+      # projected select (never reloaded) plus one lazy load of its owner — not two extra queries
+      # (a wasted Tree reload, then the owner lookup) the way an unselected FK would cost.
+      expect(selects_from(queries, 'trees').size).to eq(1)
+      expect(selects_from(queries, 'users').size).to eq(1)
+    end
+  end
+
+  # Tree#owner_name (spec/dummy's fixture) reads a column of the joined owner relation, narrowed
+  # out of that relation's own projection — reloading the Tree row itself could never produce it.
+  describe "a missing attribute that belongs to a joined relation's own record, not the root" do
+    let!(:owner) { User.create!(name: 'Michel', title: :king) }
+    let!(:tree) { Tree.create!(name: 'Oak', age: 5, owner: owner, cutter: owner) }
+
+    it 'degrades to nil immediately, without reloading, since the root record cannot fix it' do
+      expect(FOREST_LOGGER).not_to receive(:warn)
+      expect(FOREST_REPORTER).to receive(:report)
+
+      get '/forest/Tree', params: { fields: { 'Tree' => 'id,name,owner_name,owner', 'owner' => 'title' },
+                                     page: { number: '1', size: '10' }, searchExtended: '0', timezone: 'Europe/Paris' }, headers: headers
+
+      expect(response.status).to eq 200
+      body = JSON.parse(response.body)
+      expect(body['data'][0]['attributes']['owner_name']).to be_nil
     end
   end
 

--- a/spec/requests/projection_header_spec.rb
+++ b/spec/requests/projection_header_spec.rb
@@ -4,6 +4,7 @@ describe 'Requesting resources with the Forest-Projection header', :type => :req
   before(:each) do
     Address.destroy_all
     Tree.destroy_all
+    Location.destroy_all
     Island.destroy_all
     User.destroy_all
 
@@ -159,19 +160,34 @@ describe 'Requesting resources with the Forest-Projection header', :type => :req
       expect(selected).not_to include('_forest_admin_eager_load')
     end
 
-    # NOTICE: Computing a Smart Field may read any column of the record, so a projection naming
-    #         one is dropped rather than starving it, exactly as the list already does.
-    it 'reads every column when the projection names a Smart Field' do
-      allow(ForestLiana::SchemaHelper).to receive(:is_smart_field?).and_call_original
-      allow(ForestLiana::SchemaHelper).to receive(:is_smart_field?).with(User, 'cap_name').and_return(true)
+    # NOTICE: A Smart Field with no declared dependencies may read any column of the record, so a
+    #         projection naming one is dropped rather than starving it, exactly as the list
+    #         already does. User#cap_name declares its dependencies (spec/dummy's fixture) and is
+    #         therefore projectable — Location#alter_coordinates deliberately does not, pinning
+    #         the undeclared case instead.
+    it 'reads every column when the projection names a Smart Field with no declared dependencies' do
+      location = Location.create(coordinates: '1,2', island: @island)
 
-      selected = selects_of('users') do
-        get "/forest/User/#{@user.id}", headers: projecting('id,name,cap_name')
+      selected = selects_of('locations') do
+        get "/forest/Location/#{location.id}", headers: projecting('id,coordinates,alter_coordinates')
       end
 
       expect(response.status).to eq 200
-      expect(body['data']['attributes']).to include('name' => 'Michel')
-      expect(selected).to include('"users".*')
+      expect(selected).to include('"locations".*')
+    end
+
+    # User#cap_name declares dependencies: ['name'] (spec/dummy's fixture) — narrows instead of
+    # starving it, unlike the undeclared case just above.
+    it 'narrows the select to a Smart Field\'s own declared dependency, rather than reading every column' do
+      selected = selects_of('users') do
+        get "/forest/User/#{@user.id}", headers: projecting('id,cap_name')
+      end
+
+      expect(response.status).to eq 200
+      expect(body['data']['attributes']).to include('cap_name' => 'MICHEL')
+      expect(selected).to include('"users"."name"')
+      expect(selected).not_to include('"users"."title"')
+      expect(selected).not_to include('"users".*')
     end
 
     it 'serializes the whole record when the header is absent' do

--- a/spec/requests/projection_header_spec.rb
+++ b/spec/requests/projection_header_spec.rb
@@ -269,6 +269,33 @@ describe 'Requesting resources with the Forest-Projection header', :type => :req
       expect(selected).not_to include('"trees"."age"')
       expect(selected).not_to include('JOIN "users"')
     end
+
+    # A different mechanism from the Forest-Projection header above: fields[] driven, narrows only
+    # when every computed Smart Field the target collection carries declares dependencies:.
+    it "narrows the relationship route's own select when the target collection is fully declared" do
+      selected = selects_of('trees') do
+        get "/forest/Island/#{@island.id}/relationships/trees",
+          params: list_params.merge(fields: { 'Tree' => 'id,name' }), headers: auth_headers
+      end
+
+      expect(selected).to include('"trees"."name"')
+      expect(selected).not_to include('"trees"."age"')
+      expect(selected).not_to include('"trees".*')
+    end
+
+    it 'still counts and lists correctly once the target collection is narrowed' do
+      get "/forest/Island/#{@island.id}/relationships/trees/count",
+        params: { fields: { 'Tree' => 'id,name' } }, headers: auth_headers
+
+      expect(response.status).to eq 200
+      expect(body['count']).to eq(1)
+
+      get "/forest/Island/#{@island.id}/relationships/trees",
+        params: list_params.merge(fields: { 'Tree' => 'id,name' }), headers: auth_headers
+
+      expect(response.status).to eq 200
+      expect(body['data'].size).to eq(1)
+    end
   end
 
   # NOTICE: A path ending on a polymorphic relation carries no discriminant, so its targets are

--- a/spec/requests/query_footprint_spec.rb
+++ b/spec/requests/query_footprint_spec.rb
@@ -189,9 +189,9 @@ describe 'SQL footprint of a front call', type: :request do
       expect(result.per_row_delta).to eq(1)
       expect(result.per_row_delta(table: 'trees')).to eq(1)
       expect(join_count(result.grown, 'trees')).to eq(0)
-      # tree_names now declares dependencies: (['trees:name'], a relation path this ticket doesn't
-      # add to the select - PRD-1089's concern) so Owner is projectable; `name` is narrowed to
-      # because the request names it directly, same as any other requested column.
+      # tree_names now declares dependencies: (['trees:name'], a relation path that adds nothing
+      # to the select — its own preload is unimplemented today) so Owner is projectable; `name`
+      # is narrowed to because the request names it directly, same as any other requested column.
       expect(selects_from(result.grown, 'owners').first).not_to include('"owners".*')
       expect(selects_from(result.grown, 'owners').first).to include(column_ref('owners', 'name'))
     end
@@ -229,6 +229,22 @@ describe 'SQL footprint of a front call', type: :request do
       # Rails::VERSION::MAJOR.
       expect(result.per_row_delta).to eq(0)
       expect(selects_from(result.grown, 'users').size).to eq(1)
+    end
+  end
+
+  describe 'a projected list with extended search, on a collection with a polymorphic relation the request never names' do
+    let!(:resident) { User.create!(name: 'resident') }
+    let!(:address) { Address.create!(line1: '1 Main St', city: 'Town', zipcode: '00000', addressable: resident) }
+
+    after { Address.destroy_all; User.destroy_all }
+
+    it "still selects the polymorphic association's own foreign_type, needed to preload it even though it was never requested" do
+      params = { fields: { 'Address' => 'id,line1' }, page: page, searchExtended: '1', timezone: 'Europe/Paris' }
+
+      get '/forest/Address', params: params, headers: headers
+
+      expect(response).to have_http_status(200)
+      expect(listed_rows).to eq(1)
     end
   end
 end

--- a/spec/requests/query_footprint_spec.rb
+++ b/spec/requests/query_footprint_spec.rb
@@ -179,7 +179,7 @@ describe 'SQL footprint of a front call', type: :request do
 
     after { Tree.destroy_all; Owner.destroy_all }
 
-    it 'reads the relation once per row and loads every column of the root' do
+    it 'reads the relation once per row and narrows the root select to what was actually requested' do
       result = footprint(seed: seed) do |rows|
         get '/forest/Owner', params: params, headers: headers
         expect(response).to have_http_status(200)
@@ -189,7 +189,11 @@ describe 'SQL footprint of a front call', type: :request do
       expect(result.per_row_delta).to eq(1)
       expect(result.per_row_delta(table: 'trees')).to eq(1)
       expect(join_count(result.grown, 'trees')).to eq(0)
-      expect(selects_from(result.grown, 'owners').first).to include('"owners".*')
+      # tree_names now declares dependencies: (['trees:name'], a relation path this ticket doesn't
+      # add to the select - PRD-1089's concern) so Owner is projectable; `name` is narrowed to
+      # because the request names it directly, same as any other requested column.
+      expect(selects_from(result.grown, 'owners').first).not_to include('"owners".*')
+      expect(selects_from(result.grown, 'owners').first).to include(column_ref('owners', 'name'))
     end
   end
 

--- a/spec/requests/query_footprint_spec.rb
+++ b/spec/requests/query_footprint_spec.rb
@@ -209,7 +209,7 @@ describe 'SQL footprint of a front call', type: :request do
 
     after { Address.destroy_all; User.destroy_all }
 
-    it 'never joins the target and resolves it per row on Rails 6, in one batch from Rails 7' do
+    it 'never joins the target, and batch-resolves it in one query on every supported Rails version' do
       result = footprint(seed: seed) do |rows|
         get '/forest/Address', params: params, headers: headers
         expect(response).to have_http_status(200)
@@ -219,15 +219,12 @@ describe 'SQL footprint of a front call', type: :request do
       expect(join_count(result.grown, 'users')).to eq(0)
       expect(selects_from(result.grown, 'addresses').size).to eq(1)
 
-      # The batch loader for polymorphic targets in ResourcesGetter#records is gated on Rails 7,
-      # mirroring the same version fork the production code makes (resources_getter.rb).
-      if Rails.gem_version >= Gem::Version.new('7.0')
-        expect(result.per_row_delta).to eq(0)
-        expect(selects_from(result.grown, 'users').size).to eq(1)
-      else
-        expect(result.per_row_delta).to eq(1)
-        expect(result.per_row_delta(table: 'users')).to eq(1)
-      end
+      # Before this fix: 1+N queries on Rails 6.1 (one per row, via each record's own belongs_to
+      # lazy load), 1+1 from Rails 7 (BaseGetter#preload_polymorphic_associations's own branch,
+      # unchanged here). Now 1+1 on every supported version - the batch loader no longer forks on
+      # Rails::VERSION::MAJOR.
+      expect(result.per_row_delta).to eq(0)
+      expect(selects_from(result.grown, 'users').size).to eq(1)
     end
   end
 end

--- a/spec/serializers/forest_liana/missing_attribute_valve_spec.rb
+++ b/spec/serializers/forest_liana/missing_attribute_valve_spec.rb
@@ -1,0 +1,26 @@
+module ForestLiana
+  describe MissingAttributeValve do
+    let(:dummy_class) { Class.new { include ForestLiana::MissingAttributeValve } }
+    let(:dummy) { dummy_class.new }
+
+    describe '#missing_column_from (private)' do
+      it "extracts the column from Rails <= 7.0's message shape" do
+        exception = ActiveModel::MissingAttributeError.new('missing attribute: name')
+
+        expect(dummy.send(:missing_column_from, exception)).to eq('name')
+      end
+
+      it "extracts the column from Rails >= 7.1's message shape" do
+        exception = ActiveModel::MissingAttributeError.new("missing attribute 'name' for Owner")
+
+        expect(dummy.send(:missing_column_from, exception)).to eq('name')
+      end
+
+      it 'answers nil for a message shape it does not recognize' do
+        exception = ActiveModel::MissingAttributeError.new('something else entirely')
+
+        expect(dummy.send(:missing_column_from, exception)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/forest_liana/ability/assert_can_read_query_fields_spec.rb
+++ b/spec/services/forest_liana/ability/assert_can_read_query_fields_spec.rb
@@ -165,8 +165,15 @@ module ForestLiana
             expect { dummy_class.assert_can_read_query_fields(user, Address, filter_paths: ['addressable:name']) }
               .not_to raise_error
           ensure
+            # Rails 7.2 switched _reflections/reflections to symbol keys; deleting only the string
+            # form is a silent no-op there, and reflect_on_all_associations only busts its cache
+            # from add_reflection, never on a direct _reflections mutation — without the explicit
+            # clear, the deleted association keeps leaking into later specs.
             Island._reflections.delete('addresses')
+            Island._reflections.delete(:addresses)
             Island.reflections.delete('addresses')
+            Island.reflections.delete(:addresses)
+            Island.clear_reflections_cache
             %w[addresses addresses= address_ids address_ids=].each { |m| Island.undef_method(m) rescue nil }
           end
 
@@ -191,7 +198,10 @@ module ForestLiana
               )
           ensure
             Tree._reflections.delete('subject')
+            Tree._reflections.delete(:subject)
             Tree.reflections.delete('subject')
+            Tree.reflections.delete(:subject)
+            Tree.clear_reflections_cache
             %w[subject subject= subject_id subject_type].each { |m| Tree.undef_method(m) rescue nil }
           end
         end

--- a/spec/services/forest_liana/ability/redact_fields_spec.rb
+++ b/spec/services/forest_liana/ability/redact_fields_spec.rb
@@ -188,8 +188,15 @@ module ForestLiana
               user, Address, { 'addressable' => 'name' }, named_collections: []
             )).to eq('addressable' => 'name')
           ensure
+            # Rails 7.2 switched _reflections/reflections to symbol keys; deleting only the string
+            # form is a silent no-op there, and reflect_on_all_associations only busts its cache
+            # from add_reflection, never on a direct _reflections mutation — without the explicit
+            # clear, the deleted association keeps leaking into later specs.
             Island._reflections.delete('addresses')
+            Island._reflections.delete(:addresses)
             Island.reflections.delete('addresses')
+            Island.reflections.delete(:addresses)
+            Island.clear_reflections_cache
             %w[addresses addresses= address_ids address_ids=].each { |m| Island.undef_method(m) rescue nil }
           end
 
@@ -222,7 +229,10 @@ module ForestLiana
             )
           ensure
             Tree._reflections.delete('subject')
+            Tree._reflections.delete(:subject)
             Tree.reflections.delete('subject')
+            Tree.reflections.delete(:subject)
+            Tree.clear_reflections_cache
             %w[subject subject= subject_id subject_type].each { |m| Tree.undef_method(m) rescue nil }
           end
         end

--- a/spec/services/forest_liana/apimap_sorter_spec.rb
+++ b/spec/services/forest_liana/apimap_sorter_spec.rb
@@ -172,5 +172,25 @@ module ForestLiana
         end
       end
     end
+
+    describe 'a smart field dependencies key' do
+      # dependencies: is a server-side hint (what to select/preload), not part of the schema the
+      # front end consumes — KEYS_COLLECTION_FIELD's slice is what keeps it out of the payload.
+      let(:apimap) do
+        {
+          meta: { liana: 'forest-rails', liana_version: '1.0.0', stack: { orm_version: '1', database_type: 'sqlite' } },
+          data: [{
+            id: 'trees', type: 'collections',
+            attributes: { name: 'trees', fields: [{ field: 'cap_name', type: 'String', dependencies: ['name'] }] }
+          }]
+        }
+      end
+
+      it 'is stripped from the emitted field payload' do
+        sorted = described_class.new(apimap).perform
+
+        expect(sorted['data'][0]['attributes']['fields'][0]).not_to have_key('dependencies')
+      end
+    end
   end
 end

--- a/spec/services/forest_liana/base_getter_spec.rb
+++ b/spec/services/forest_liana/base_getter_spec.rb
@@ -1,0 +1,62 @@
+module ForestLiana
+  describe BaseGetter do
+    let(:dummy_class) { Class.new(BaseGetter) }
+    let(:getter) { dummy_class.new }
+
+    before do
+      Address.destroy_all
+      User.destroy_all
+    end
+
+    after { Address.destroy_all; User.destroy_all }
+
+    describe '#preload_polymorphic_associations' do
+      # Address#addressable is a real polymorphic belongs_to in the dummy app - exercised
+      # directly here rather than through a getter, so this pins the shared mechanism itself
+      # regardless of which getter subclass calls it.
+      it 'resolves the polymorphic target without joining it, on this Rails version' do
+        michel = User.create!(name: 'Michel')
+        robert = User.create!(name: 'Robert')
+        # Reverse creation order from the query's own id order, so a naive record[i] <-> owner[i]
+        # pairing (instead of matching by id) would assign the wrong target to each row.
+        address_2 = Address.create!(line1: '2 Palm Street', city: 'Papeete', zipcode: '00000', addressable: robert)
+        address_1 = Address.create!(line1: '1 Palm Street', city: 'Papeete', zipcode: '00000', addressable: michel)
+
+        records = Address.where(id: [address_1.id, address_2.id]).order(:id).to_a
+        queries = []
+        subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+          queries << payload[:sql] unless payload[:cached] || payload[:name] == 'SCHEMA'
+        end
+        begin
+          getter.send(:preload_polymorphic_associations, records, [:addressable])
+        ensure
+          ActiveSupport::Notifications.unsubscribe(subscriber)
+        end
+
+        expect(queries.size).to eq(1)
+        expect(queries.first).not_to match(/JOIN/i)
+
+        # A wrong record<->owner pairing wouldn't necessarily read back a wrong value (a record
+        # left without its own singleton override just falls through to Rails' own lazy belongs_to
+        # load, still correct) - it would issue an extra query instead, silently defeating the
+        # preload. Checked with a second subscription, isolated from the one above.
+        further_queries = []
+        subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+          further_queries << payload[:sql] unless payload[:cached] || payload[:name] == 'SCHEMA'
+        end
+        begin
+          expect(records.find { |r| r.id == address_1.id }.addressable).to eq(michel)
+          expect(records.find { |r| r.id == address_2.id }.addressable).to eq(robert)
+        ensure
+          ActiveSupport::Notifications.unsubscribe(subscriber)
+        end
+        expect(further_queries).to be_empty
+      end
+
+      it 'does nothing for an empty association list or an empty record set' do
+        expect { getter.send(:preload_polymorphic_associations, [], [:addressable]) }.not_to raise_error
+        expect { getter.send(:preload_polymorphic_associations, [Address.new], []) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/services/forest_liana/field_path_spec.rb
+++ b/spec/services/forest_liana/field_path_spec.rb
@@ -59,10 +59,17 @@ module ForestLiana
         end
 
         after do
+          # Rails 7.2 switched _reflections/reflections to symbol keys; deleting only the string
+          # form is a silent no-op there, and reflect_on_all_associations only busts its cache
+          # from add_reflection, never on a direct _reflections mutation — without the explicit
+          # clear, the deleted association keeps leaking into later specs.
           %w[addresses].each do |name|
             Island._reflections.delete(name)
+            Island._reflections.delete(name.to_sym)
             Island.reflections.delete(name)
+            Island.reflections.delete(name.to_sym)
           end
+          Island.clear_reflections_cache
           %w[addresses addresses= address_ids address_ids=].each do |method|
             Island.undef_method(method) rescue nil
           end
@@ -84,10 +91,15 @@ module ForestLiana
         end
 
         after do
+          # Same reflections-cache leak as the context above, on Tree's subject instead of
+          # Island's addresses.
           %w[subject].each do |name|
             Tree._reflections.delete(name)
+            Tree._reflections.delete(name.to_sym)
             Tree.reflections.delete(name)
+            Tree.reflections.delete(name.to_sym)
           end
+          Tree.clear_reflections_cache
           %w[subject subject= subject_id subject_type].each do |method|
             Tree.undef_method(method) rescue nil
           end

--- a/spec/services/forest_liana/resources_getter_spec.rb
+++ b/spec/services/forest_liana/resources_getter_spec.rb
@@ -139,6 +139,18 @@ module ForestLiana
       end
     end
 
+    describe 'when the collection has no relation at all in the request' do
+      let(:fields) { { 'User' => 'id,name' } }
+
+      it 'still projects the select, narrowed to the requested columns' do
+        sql = getter.perform.to_sql
+
+        expect(sql).to include('"users"."name"')
+        expect(sql).not_to include('"title"')
+        expect(sql).not_to include('"users".*')
+      end
+    end
+
     describe 'when there are more records than the page size' do
       describe 'when asking for the 1st page and 15 records' do
         let(:pageSize) { 15 }
@@ -217,6 +229,7 @@ module ForestLiana
     describe 'when sorting by a specific field' do
       let(:pageSize) { 5 }
       let(:sort) { '-name' }
+      let(:fields) { { resource.name => 'id,name' } }
 
       it 'should get only the expected records' do
         getter.perform
@@ -288,7 +301,7 @@ module ForestLiana
 
     describe 'when getting instance dependent associations' do
       let(:resource) { Island }
-      let(:fields) { { 'Island' => 'id,eponymous_tree', 'eponymous_tree' => 'id,name'} }
+      let(:fields) { { 'Island' => 'id,name,eponymous_tree', 'eponymous_tree' => 'id,name'} }
 
       it 'should get only the expected records' do
         getter.perform
@@ -348,7 +361,7 @@ module ForestLiana
 
     describe 'when filtering on before x hours ago' do
       let(:resource) { Tree }
-      let(:fields) { { 'Tree' => 'id' } }
+      let(:fields) { { 'Tree' => 'id,name' } }
       let(:filters) { {
         field: 'created_at',
         operator: 'before_x_hours_ago',
@@ -368,7 +381,7 @@ module ForestLiana
 
     describe 'when filtering on after x hours ago' do
       let(:resource) { Tree }
-      let(:fields) { { 'Tree' => 'id' } }
+      let(:fields) { { 'Tree' => 'id,name' } }
       let(:filters) { {
         field: 'created_at',
         operator: 'after_x_hours_ago',
@@ -409,6 +422,7 @@ module ForestLiana
 
     describe 'when filtering on an updated_at field of the main collection' do
       let(:resource) { Island }
+      let(:fields) { { 'Island' => 'id,name' } }
       let(:filters) { {
         field: 'updated_at',
         operator: 'previous_year'
@@ -492,6 +506,7 @@ module ForestLiana
     end
 
     describe 'when filtering on a smart field' do
+      let(:fields) { { 'User' => 'id,name' } }
       let(:filters) { {
         field: 'cap_name',
         operator: 'equal',
@@ -529,7 +544,7 @@ module ForestLiana
     describe 'when scopes are defined' do
       let(:resource) { Island }
       let(:pageSize) { 15 }
-      let(:fields) { { resource.name => 'id' } }
+      let(:fields) { { resource.name => 'id,name' } }
       let(:filters) { }
       let(:scopes) {
         {

--- a/spec/services/forest_liana/schema_adapter_spec.rb
+++ b/spec/services/forest_liana/schema_adapter_spec.rb
@@ -93,7 +93,8 @@ module ForestLiana
               "location",
               "name",
               "owner",
-              "updated_at"
+              "updated_at",
+              "name_with_age"
             ]
           )
         end

--- a/spec/services/forest_liana/schema_adapter_spec.rb
+++ b/spec/services/forest_liana/schema_adapter_spec.rb
@@ -77,7 +77,7 @@ module ForestLiana
       end
 
       context 'with standard fields' do
-        it 'should be sort by alphabetical order' do
+        it 'sorts real columns alphabetically, with smart fields appended afterward in declaration order' do
           collection = ForestLiana.apimap.find do |object|
             object.name.to_s == ForestLiana.name_for(Tree)
           end
@@ -94,7 +94,9 @@ module ForestLiana
               "name",
               "owner",
               "updated_at",
-              "name_with_age"
+              "name_with_age",
+              "owner_name",
+              "owner_name_declared"
             ]
           )
         end

--- a/spec/services/forest_liana/smart_field_dependencies_spec.rb
+++ b/spec/services/forest_liana/smart_field_dependencies_spec.rb
@@ -63,7 +63,7 @@ module ForestLiana
 
       it 'warns and drops the whole declaration for a bare name that is not a real column' do
         field = { field: :cap_name, dependencies: ['not_a_column'] }
-        expect(FOREST_LOGGER).to receive(:warn)
+        expect(FOREST_LOGGER).to receive(:warn).with(/not_a_column.*cap_name.*Tree/m)
 
         described_class.validate!(Tree, 'Tree', field)
 
@@ -72,7 +72,7 @@ module ForestLiana
 
       it 'warns and drops the whole declaration for a relation path naming a fake association' do
         field = { field: :cap_name, dependencies: ['not_a_relation:name'] }
-        expect(FOREST_LOGGER).to receive(:warn)
+        expect(FOREST_LOGGER).to receive(:warn).with(/not_a_relation:name.*cap_name.*Tree/m)
 
         described_class.validate!(Tree, 'Tree', field)
 
@@ -82,11 +82,27 @@ module ForestLiana
       it 'warns and drops the whole declaration for a path crossing a polymorphic relation' do
         Tree.class_eval { belongs_to :subject, polymorphic: true, optional: true }
         field = { field: :cap_name, dependencies: ['subject:name'] }
-        expect(FOREST_LOGGER).to receive(:warn)
+        expect(FOREST_LOGGER).to receive(:warn).with(/subject:name.*cap_name.*Tree/m)
 
         described_class.validate!(Tree, 'Tree', field)
 
         expect(field).not_to have_key(:dependencies)
+      end
+
+      it "warns and drops the whole declaration rather than crash the boot when a relation's class_name doesn't exist" do
+        Tree.class_eval { belongs_to :ghost, class_name: 'TotallyNotARealClass', optional: true }
+        field = { field: :cap_name, dependencies: ['ghost:name'] }
+        expect(FOREST_LOGGER).to receive(:warn).with(/ghost:name.*cap_name.*Tree/m)
+
+        expect { described_class.validate!(Tree, 'Tree', field) }.not_to raise_error
+        expect(field).not_to have_key(:dependencies)
+      ensure
+        Tree._reflections.delete('ghost')
+        Tree._reflections.delete(:ghost)
+        Tree.reflections.delete('ghost')
+        Tree.reflections.delete(:ghost)
+        Tree.clear_reflections_cache
+        %w[ghost ghost= ghost_id].each { |m| Tree.undef_method(m) rescue nil }
       end
 
       it 'does nothing when dependencies is absent' do

--- a/spec/services/forest_liana/smart_field_dependencies_spec.rb
+++ b/spec/services/forest_liana/smart_field_dependencies_spec.rb
@@ -1,0 +1,102 @@
+module ForestLiana
+  describe SmartFieldDependencies do
+    describe '.normalize' do
+      it 'wraps a bare String or Symbol into an Array' do
+        expect(described_class.normalize('name')).to eq(['name'])
+        expect(described_class.normalize(:name)).to eq(['name'])
+      end
+
+      it 'strips, dedupes and drops empty entries of an Array' do
+        expect(described_class.normalize([' name ', 'name', '', 'age'])).to eq(%w[name age])
+      end
+
+      it 'accepts an empty Array' do
+        expect(described_class.normalize([])).to eq([])
+      end
+
+      it 'answers nil for a shape that is neither a String, a Symbol, nor an Array' do
+        expect(described_class.normalize({ nested: 'hash' })).to be_nil
+        expect(described_class.normalize(5)).to be_nil
+        expect(described_class.normalize(nil)).to be_nil
+      end
+    end
+
+    describe '#columns and #relation_paths' do
+      let(:dependencies) { described_class.new(['name', 'island:name', 'island:location:coordinates']) }
+
+      it 'splits bare column names from relation paths' do
+        expect(dependencies.columns).to eq(['name'])
+      end
+
+      it 'parses each relation path into its relations and final column' do
+        expect(dependencies.relation_paths).to eq([
+          described_class::RelationPath.new(['island'], 'name'),
+          described_class::RelationPath.new(%w[island location], 'coordinates')
+        ])
+      end
+    end
+
+    describe '.validate!' do
+      after do
+        Tree._reflections.delete('subject')
+        Tree.reflections.delete('subject')
+        %w[subject subject= subject_id subject_type].each { |m| Tree.undef_method(m) rescue nil }
+      end
+
+      it 'keeps a bare column name that is a real column of the model' do
+        field = { field: :cap_name, dependencies: ['name'] }
+
+        expect(FOREST_LOGGER).not_to receive(:warn)
+        described_class.validate!(Tree, 'Tree', field)
+
+        expect(field[:dependencies]).to eq(['name'])
+      end
+
+      it 'keeps a relation path resolving to a real column on the target model' do
+        field = { field: :cap_name, dependencies: ['island:name'] }
+
+        expect(FOREST_LOGGER).not_to receive(:warn)
+        described_class.validate!(Tree, 'Tree', field)
+
+        expect(field[:dependencies]).to eq(['island:name'])
+      end
+
+      it 'warns and drops the whole declaration for a bare name that is not a real column' do
+        field = { field: :cap_name, dependencies: ['not_a_column'] }
+        expect(FOREST_LOGGER).to receive(:warn)
+
+        described_class.validate!(Tree, 'Tree', field)
+
+        expect(field).not_to have_key(:dependencies)
+      end
+
+      it 'warns and drops the whole declaration for a relation path naming a fake association' do
+        field = { field: :cap_name, dependencies: ['not_a_relation:name'] }
+        expect(FOREST_LOGGER).to receive(:warn)
+
+        described_class.validate!(Tree, 'Tree', field)
+
+        expect(field).not_to have_key(:dependencies)
+      end
+
+      it 'warns and drops the whole declaration for a path crossing a polymorphic relation' do
+        Tree.class_eval { belongs_to :subject, polymorphic: true, optional: true }
+        field = { field: :cap_name, dependencies: ['subject:name'] }
+        expect(FOREST_LOGGER).to receive(:warn)
+
+        described_class.validate!(Tree, 'Tree', field)
+
+        expect(field).not_to have_key(:dependencies)
+      end
+
+      it 'does nothing when dependencies is absent' do
+        field = { field: :cap_name }
+        expect(FOREST_LOGGER).not_to receive(:warn)
+
+        described_class.validate!(Tree, 'Tree', field)
+
+        expect(field).not_to have_key(:dependencies)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Column half of the "let a smart field declare what it needs, and go lazy where every consumer has" ticket — the relation-preload half is a separate follow-up ticket, out of scope here. Stacked on `feature/optim-rbac-capabilities` (now including #797) — base branch is `feature/optim-rbac-capabilities`, not `main`.

## Why

A smart field's getter is `object.instance_eval(&block)` — it runs in the record's own context, so it can read any column, including transitively through model code the agent can't see. The agent can't infer what to select, so today it defensively loads every column the moment a single smart field is projected. This makes an opt-in declaration the only way to select less for a collection **carrying a smart field**.

That caveat matters: a collection with **no** smart field at all needs no opt-in and starts projecting immediately on this PR landing — a relation-less list that got `SELECT *` before now gets only what was requested. 6 existing specs needed a wider `fields:` for exactly this reason (they read a column off the AR object post-`perform` without requesting it). The `MissingAttributeValve` only wraps smart-field getters — an `after_find`, a `to_s` override, a `default_scope`, a decorator, or a smart action reading an unrequested column on one of these newly-projected collections is outside its reach, and would 500 instead of degrading.

## What

- A new `dependencies:` option on `field`/`has_many`/`belongs_to`, alongside the existing DSL options. A bare name is a column to select; an `a:b` path names a relation to preload (parsed and validated here, not yet consumed — that's the follow-up ticket). Absent, invalid, or normalized-away, a field is treated exactly as if it declared nothing.
- Adoption is per request, not per collection: a request only goes lazy-select when every smart field or smart relation it actually names is either a declared computed field or controlled some other way — `should_include_attr?` never evaluates a field the request didn't ask for, so one undeclared getter elsewhere on the collection can't affect a request that never names it. (An earlier version of this PR made it collection-wide instead — corrected after review: that version regressed every existing collection's `show`/`relationships` projection on day one, for a risk `should_include_attr?` already rules out.)
- `dependencies:` is accepted, normalized and validated on `has_many`/`belongs_to` exactly like on `field`, but nothing reads it back yet — requesting a smart relation, declared or not, still falls back to the unprojected path for that request. Wiring it up (so a declared smart relation's own columns can also narrow the select) is left to a follow-up.
- A safety valve for the case a declaration is incomplete rather than absent (a genuine mistake, or a getter reaching through model code the agent can't see): `MissingAttributeError` is rescued once, the record reloaded (its already-loaded associations preserved across the reload), and a warning logged naming the field and the missing column. A second failure degrades to `nil`, never a 500.
- The primary key and every foreign key the serializer will need to emit relationships are always selected regardless of the projection, the same guard the redaction ticket needed.
- Polymorphic associations are now batch-resolved through `ActiveRecord::Associations::Preloader` on Rails 6.1 too (previously gated to Rails ≥ 7, one query per record on 6.1) — including on the has-many relationship route, which didn't preload them at all before this.

## Known gaps

- A relation-path dependency's own preload is the follow-up ticket's job, not this one's — declaring one still makes its collection lazy-select-eligible without adding anything to the select for that relation. For a `has_many`/`has_one` path this costs nothing extra (the association loads via its own query regardless of the parent's select). For a `belongs_to` path, the association's own foreign key is proactively selected here specifically to avoid a wasted valve reload — but the target's own columns are still read via an ordinary lazy load, same as if no dependency had been declared at all.
- `SmartFieldDependencies::RelationPath`/`#relation_paths` are parsed and validated but have no consumer yet — dead code until the follow-up ticket lands, kept here so that ticket only adds the preloading, not a second parser.
- A polymorphic association reached only through a smart-field's own model code (not declared in `dependencies:`, not requested as a field) can still cost a query per record on the has-many relationship route under extended search — narrower than before this PR, not eliminated.

## Verification

839 examples, 0 failures, green on every supported Rails version (6.1 through 8.1). Before/after footprints, measured with the request-level query-count harness (`spec/requests/query_footprint_spec.rb`):

- **Polymorphic association on Rails 6.1**: 1+N queries (one per row, via each record's own lazy `belongs_to` load) → 1+1 (one batched query resolving every target), matching what Rails ≥ 7 already had.
- **A smart field walking a to-many relation** (`Owner#tree_names`, declaring only a relation-path dependency): root select narrows from `SELECT "owners".*` to the requested columns only; the per-row relation load itself (out of scope here) is unchanged.
- **A smart field reading an under-declared column**: correct value served, one extra query *per row* (the reload) — but the warning naming the field and column logs once per process, not once per row (fixed after review: it originally warned on every row, which would have meant thousands of identical lines on a large page). Never a 500 or a silently wrong value, pinned as the adoption-blocking criterion the ticket calls out.

fixes PRD-1086


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add smart-field dependency declarations and lazy projection to getters
> - Smart fields can now declare `dependencies` (bare columns or colon-delimited relation paths) so the server knows which columns to select. The new [smart_field_dependencies.rb](app/services/forest_liana/smart_field_dependencies.rb) normalizes and validates declarations at bootstrap, removing invalid ones with a warning.
> - [Collection](app/models/forest_liana/model/collection.rb) classifies computed smart fields (with declared dependencies) as projectable, while smart relations and integration fields are not. `ResourcesGetter`, `HasManyGetter`, and `ResourceGetter` use this check instead of rejecting projection whenever any smart field is requested.
> - Getters now save the unprojected relation before projecting and use it for counts, so projected column selection no longer breaks count queries.
> - A new [MissingAttributeValve](app/serializers/forest_liana/missing_attribute_valve.rb) serializer module catches `ActiveModel::MissingAttributeError`, reloads the record once (preserving loaded associations), retries evaluation, and degrades to a reported nil on failure. This guards cases where a declared dependency is incomplete or absent.
> - Polymorphic association preloading moves to a shared helper in [base_getter.rb](app/services/forest_liana/base_getter.rb), working on both Rails 6 and Rails 7 and assigning targets to the exact returned record objects.
> - Risk: smart-field getters that previously swallowed `MissingAttributeError` and returned nil now propagate it to the valve, which may reload the record and emit a process-level warning; collections with unresolved models are skipped during dependency validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5807e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
